### PR TITLE
fix(auth): improve auth flow and cleanup unused code

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -14,6 +14,7 @@ export default tseslint.config(
       globals: globals.browser,
     },
     plugins: {
+      "@typescript-eslint": tseslint.plugin,
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
     },
@@ -25,6 +26,7 @@ export default tseslint.config(
       ],
       // ES2015 module syntax is preferred over namespaces.eslint@typescript-eslint/no-namespace
       "no-namespace": "off",
+      "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
@@ -32,6 +34,7 @@ export default tseslint.config(
           args: "none",
           ignoreRestSiblings: true,
           varsIgnorePattern: "^_",
+          argsIgnorePattern: "^_",
           caughtErrors: "none",
         },
       ],

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -3,6 +3,7 @@ export const API = IsDockerHost ? "/api" : "http://localhost:27018/api";
 
 export const GetCookie = (name: string) => {
   const cookie = document.cookie
+    .replace(/\s/g, "")
     .split(";")
     .find((c) => c.startsWith(`${name}=`));
   return cookie?.split("=")[1];

--- a/web/src/components/auth/authModal.tsx
+++ b/web/src/components/auth/authModal.tsx
@@ -10,15 +10,16 @@ import {
   Tabs,
 } from "@heroui/react";
 import React, { useState } from "react";
-import { useAuthStore } from "../../stores/auth.store";
-import { AuthAPI } from "../../api/auth";
 import { toast } from "sonner";
+import { AuthAPI } from "../../api/auth";
+import { useAuthStore } from "../../stores/auth.store";
 
 const AuthModal: React.FC = () => {
   const [activeTab, setActiveTab] = useState("login");
   const [formData, setFormData] = useState({ email: "", password: "" });
   const [loading, setLoading] = useState(false);
-  const { isAuthModalOpen, setIsAuthModalOpen, setUser } = useAuthStore();
+  const { isAuthModalOpen, setIsAuthModalOpen, getCurrentUser } =
+    useAuthStore();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -38,19 +39,16 @@ const AuthModal: React.FC = () => {
             password: formData.password,
           });
 
-    console.log("Error:", error, data);
-
     if (data) {
       toast.success(data.message);
-      setUser(data.user);
-      useAuthStore.setState({ isAuth: true });
-      window.location.reload();
     }
+
     if (error) {
       toast.error("Invalid Credentials");
     }
-
     setLoading(false);
+
+    getCurrentUser();
   };
 
   return (

--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -1,4 +1,3 @@
-import { GetCookie } from "../api";
 import { useAuthStore } from "../stores/auth.store";
 import AuthModal from "./auth/authModal";
 import TopNavbar from "./navbar";
@@ -10,19 +9,11 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  const { getCurrentUser, user, setIsAuthModalOpen, isAuth } = useAuthStore();
+  const { getCurrentUser, user, isAuth } = useAuthStore();
 
   useEffect(() => {
     getCurrentUser();
   }, []);
-
-  const crfToken = GetCookie("csrf");
-
-  useEffect(() => {
-    if (!user && !crfToken) {
-      setIsAuthModalOpen(true);
-    }
-  }, [user, crfToken]);
 
   return (
     <div className="flex flex-col mx-auto">

--- a/web/src/stores/auth.store.ts
+++ b/web/src/stores/auth.store.ts
@@ -28,9 +28,8 @@ export const useAuthStore = create<AuthStore>((set) => ({
   getCurrentUser: async () => {
     const { user, error } = await AuthAPI.CurretUserRequest();
     if (error?.error) {
-      console.error(error);
       toast.error(error.error);
-      ClearCookies();
+      set({ isAuthModalOpen: true });
       set({ isAuth: false });
       set({ user: null });
       return;


### PR DESCRIPTION
Remove unused GetCookie import and related logic from Layout to simplify authentication checks. Update auth store to open auth modal on user fetch failure instead of clearing cookies. Refactor AuthModal to call getCurrentUser after login instead of reloading the page, improving UX. Adjust ESLint config to disable no-unused-vars rule and add missing plugin. Fix GetCookie to handle whitespace in cookies correctly. These changes enhance auth state handling and code maintainability.