### PR TITLE
feat(snapshot): support custom/default storage and add download

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func routes(app *fiber.App) {
 	connectionGroup.Post("/", controllers.AddConnection)
 	connectionGroup.Get("/:ConnID/sync-db", middlewares.IsConnectionBelongToUser, controllers.SyncConnectionDatabases)
 	connectionGroup.Get("/:ConnID/status", middlewares.IsConnectionBelongToUser, controllers.GetClusterStatus)
+	connectionGroup.Patch("/:ConnID/default-storage/:StorageID", middlewares.IsConnectionBelongToUser, controllers.SetDefaultStorageForConnection)
 
 	// [Snapshot Routes]
 	snapshotGroup := api.Group("/snapshot", middlewares.Auth)
@@ -76,6 +77,8 @@ func routes(app *fiber.App) {
 	snapshotGroup.Get("/:ConnID/:SnapID", middlewares.IsConnectionBelongToUser, controllers.GetSnapshot)
 	snapshotGroup.Get("/:ConnID/:SnapID/download", middlewares.IsConnectionBelongToUser, controllers.DownloadSnapshot)
 	snapshotGroup.Patch("/:ConnID/:SnapID/tags", middlewares.IsConnectionBelongToUser, controllers.UpdateSnapshotTags)
+	snapshotGroup.Delete("/:ConnID/:SnapID", middlewares.IsConnectionBelongToUser, controllers.DeleteSnapshot)
+	snapshotGroup.Get("/:ConnID/:SnapID/download", middlewares.IsConnectionBelongToUser, controllers.DownloadSnapshotFromStorage)
 
 	// [Restore Routes]
 	restoreGroup := api.Group("/restore", middlewares.Auth)

--- a/src/controllers/connection.controller.go
+++ b/src/controllers/connection.controller.go
@@ -78,3 +78,19 @@ func GetClusterStatus(
 		"status": Status,
 	})
 }
+
+func SetDefaultStorageForConnection(
+	c *fiber.Ctx,
+) error {
+	ConnID := c.Params("ConnID")
+	StorageID := c.Params("StorageID")
+	err := services.SetDefaultStorageForConnection(ConnID, StorageID)
+	if err != nil {
+		return c.JSON(fiber.Map{
+			"error": err,
+		})
+	}
+	return c.JSON(fiber.Map{
+		"message": "Default storage set",
+	})
+}

--- a/src/controllers/snapshot.controller.go
+++ b/src/controllers/snapshot.controller.go
@@ -90,6 +90,23 @@ func DownloadSnapshot(
 	)
 }
 
+func DownloadSnapshotFromStorage(
+	c *fiber.Ctx,
+) error {
+	SnapID := c.Params("SnapID")
+	downloadPath, error := services.DownloadSnapshotFromStorage(SnapID)
+	slog.Info("Downloading Snapshot from Storage", "SnapshotID", SnapID, "OutputFile", downloadPath)
+	if error != nil {
+		return c.JSON(fiber.Map{
+			"error": error.Error(),
+		})
+	}
+	return c.JSON(fiber.Map{
+		"message": "Snapshot has been downloaded from storage",
+		"url":     downloadPath,
+	})
+}
+
 func UpdateSnapshotTags(
 	c *fiber.Ctx,
 ) error {
@@ -110,4 +127,19 @@ func UpdateSnapshotTags(
 		})
 	}
 	return c.JSON(snap)
+}
+
+func DeleteSnapshot(
+	c *fiber.Ctx,
+) error {
+	SnapID := c.Params("SnapID")
+	err := services.DeleteSnapshot(SnapID)
+	if err != nil {
+		return c.JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+	return c.JSON(fiber.Map{
+		"message": "Snapshot has been deleted",
+	})
 }

--- a/src/interfaces/connection.interface.go
+++ b/src/interfaces/connection.interface.go
@@ -16,4 +16,5 @@ type Connection struct {
 		Database    string   `json:"database"`
 		Collections []string `json:"collections"`
 	} `json:"collections"`
+	DefaultStorageID string `json:"defaultStorageID"`
 }

--- a/src/services/connection.service.go
+++ b/src/services/connection.service.go
@@ -241,3 +241,25 @@ func SyncConnectionDatabases(
 	return databases
 	// return connection
 }
+
+func SetDefaultStorageForConnection(
+	connectionID string,
+	defaultStorageID string,
+) error {
+	var Collection = global.GetCollection("connections")
+	_, err := Collection.UpdateOne(
+		context.TODO(),
+		bson.M{"connectionID": connectionID},
+		bson.D{
+			{Key: "$set", Value: bson.D{
+				{Key: "defaultStorageID", Value: defaultStorageID},
+			}},
+		},
+	)
+	if err != nil {
+		fmt.Println("Error updating connection")
+		fmt.Println(err)
+		return err
+	}
+	return nil
+}

--- a/src/services/restore.service.go
+++ b/src/services/restore.service.go
@@ -68,7 +68,7 @@ func RestoreSnapshot(
 			// update snapshot
 			_, err := Collection.UpdateOne(
 				context.TODO(),
-				bson.M{"_id": snapshotID},
+				bson.M{"snapshotID": snapshotID},
 				bson.M{"$set": bson.M{"artifact": artifact}},
 			)
 			if err != nil {

--- a/src/services/storage.service.go
+++ b/src/services/storage.service.go
@@ -57,7 +57,7 @@ type UpdateStorageParams struct {
 	StorageID string
 	Name      string
 	Type      interfaces.StorageType
-	Storage   interface{}
+	Storage   interfaces.StorageUnion
 	UserID    string
 	IsDefault bool
 }
@@ -74,10 +74,14 @@ func UpdateStorage(params UpdateStorageParams) (interfaces.Storage, error) {
 		},
 		bson.M{
 			"$set": bson.M{
-				"name":      params.Name,
-				"type":      params.Type,
-				"storageID": params.StorageID,
-				"storage":   params.Storage,
+				"name":              params.Name,
+				"type":              params.Type,
+				"storageID":         params.StorageID,
+				"storage.bucket":    params.Storage.Bucket,
+				"storage.region":    params.Storage.Region,
+				"storage.folder":    params.Storage.Folder,
+				"storage.accessKey": params.Storage.AccessKey,
+				"storage.secretKey": params.Storage.SecretKey,
 			},
 		},
 		options.FindOneAndUpdate().SetReturnDocument(options.After),


### PR DESCRIPTION
- Use connectionStorageID when snapshots: prefer an configured storage for a connection and fall back to the user's default storage. Construct storageInstance and map its fields into the upload payload (Type, StorageID) to avoid referencing the old 'storage' variable.
- Fix IsDefault checks and storageID references to use storageInstance.
- Add DownloadSnapshotFromStorage: fetch snapshot, refresh expired presigned URL via storage adapter, update snapshot document, and return URL.
- Add DeleteSnapshot: remove artifact from storage (via storage adapter) if present and delete snapshot document from DB.
- Add controller endpoints: DownloadSnapshotFromStorage and DeleteSnapshot to expose new functionality via HTTP.
- Add SetDefaultStorageForConnection controller and service to set connection.DefaultStorageID in the connections collection.
- Extend Connection interface with DefaultStorageID field.
- Extend storage interface and adapters with GetPresignedURL method and implement for Storage wrapper and S3 adapter; also update DeleteFile implementation for S3 to use DeleteObject.
- Fix a lookup bug in restore.service: query snapshot by snapshotID instead of _id.

These changes enable per-connection storage selection, lifecycle operations for snapshot artifacts (refresh presigned URLs and deletion), and admin endpoints to manage/default storage for connections.