### PR TITLE
feat-add-backup-scheduling-restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 /tmp
 .stuffs
 _stuffs
+comp_backups
 bin
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ backend-dev:
 dev:
 	@echo "Starting Dev Server"
 	@make web-dev & make backend-dev
+
+build-docker:
+	docker build -t mongo-stuff .

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/joho/godotenv v1.5.1
+	github.com/robfig/cron/v3 v3.0.1
 	go.mongodb.org/mongo-driver v1.17.1
 	golang.org/x/crypto v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"mongostuff/src/controllers"
 	global "mongostuff/src/globals"
 	"mongostuff/src/middlewares"
+	"mongostuff/src/services"
 	"os"
 
 	"github.com/gofiber/fiber/v2"
@@ -23,19 +24,17 @@ func init() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	slog.SetDefault(logger)
 
-	// Local Storage
-	// if _stuffs/snapshots folder doesn't exist, create it
-	if _, err := os.Stat("./_stuffs"); os.IsNotExist(err) {
-		err := os.Mkdir("./_stuffs", 0755) // 0755 is the octal representation of rwxr-xr-x
-		if err != nil {
-			slog.Error("Error creating _stuffs directory", "error", err)
+	folderRequired := []string{"./_stuffs", "./_stuffs/snapshots", "./_stuffs/backups"}
+
+	// check if folder exists
+	for _, folder := range folderRequired {
+		if _, err := os.Stat(folder); os.IsNotExist(err) {
+			err := os.Mkdir(folder, 0755) // 0755 is the octal representation of rwxr-xr-x
+			if err != nil {
+				slog.Error("Error creating _stuffs directory", "error", err)
+			}
+			slog.Info("Created _stuffs/snapshots directory")
 		}
-		slog.Info("Created _stuffs/snapshots directory")
-		err = os.Mkdir("./_stuffs/snapshots", 0755)
-		if err != nil {
-			slog.Error("Error creating _stuffs directory", "error", err)
-		}
-		slog.Info("Created _stuffs/snapshots directory")
 	}
 
 }
@@ -83,8 +82,9 @@ func routes(app *fiber.App) {
 	// [Restore Routes]
 	restoreGroup := api.Group("/restore", middlewares.Auth)
 	restoreGroup.Get("/:ConnID", middlewares.IsConnectionBelongToUser, controllers.GetRestores)
-	restoreGroup.Post("/:ConnID/:SnapID", middlewares.IsConnectionBelongToUser, controllers.RestoreSnapshot)
+	restoreGroup.Post("/:ConnID/:SnapID/snapshot", middlewares.IsConnectionBelongToUser, controllers.RestoreSnapshot)
 	restoreGroup.Get("/:ConnID/:RestoreID", middlewares.IsConnectionBelongToUser, controllers.GetRestore)
+	restoreGroup.Post("/:ConnID/:BackupID/backup", middlewares.IsConnectionBelongToUser, controllers.RestoreBackup)
 
 	// [Auth Routes]
 	authGroup := api.Group("/auth")
@@ -101,6 +101,21 @@ func routes(app *fiber.App) {
 	storageGroup.Patch("/:StorageID", controllers.UpdateStorage)
 	storageGroup.Delete("/:StorageID", controllers.DeleteStorage)
 	storageGroup.Patch("/:StorageID/default", controllers.SetDefaultStorage)
+
+	// [Backup Policies]
+	backupPolicyGroup := api.Group("/backup-policy", middlewares.Auth)
+	backupPolicyGroup.Post("/:ConnID", middlewares.IsConnectionBelongToUser, controllers.CreateBackupPolicy)
+	backupPolicyGroup.Get("/:ConnID", middlewares.IsConnectionBelongToUser, controllers.GetBackupPolicies)
+	backupPolicyGroup.Get("/:ConnID/:BackupPolicyID", middlewares.IsConnectionBelongToUser, controllers.GetBackupPolicy)
+	backupPolicyGroup.Patch("/:ConnID/:BackupPolicyID", middlewares.IsConnectionBelongToUser, controllers.UpdateBackupPolicy)
+	backupPolicyGroup.Delete("/:ConnID/:BackupPolicyID", middlewares.IsConnectionBelongToUser, controllers.DeleteBackupPolicy)
+	backupPolicyGroup.Put("/:ConnID/:BackupPolicyID/trigger", middlewares.IsConnectionBelongToUser, controllers.TriggerBackup)
+
+
+	// [Backup]
+	backupGroup := api.Group("/backup", middlewares.Auth)
+	backupGroup.Get("/:ConnID", middlewares.IsConnectionBelongToUser, controllers.BackupsForConnection)
+	backupGroup.Get("/:ConnID/:BackupPolicyID", middlewares.IsConnectionBelongToUser, controllers.BackupsForPolicy)
 
 	// Serve Static Files
 	app.Static("/", "./web/dist", fiber.Static{
@@ -129,11 +144,12 @@ func main() {
 	}
 
 	routes(app)
+	services.InitCron()
+
 	if err := app.Listen(
 		":" + os.Getenv("PORT"),
 	); err != nil {
 		panic(err)
 	}
 	fmt.Println("Server started on port " + os.Getenv("PORT"))
-
 }

--- a/src/controllers/backup.controller.go
+++ b/src/controllers/backup.controller.go
@@ -1,0 +1,223 @@
+package controllers
+
+import (
+	"log/slog"
+	"mongostuff/src/interfaces"
+	"mongostuff/src/services"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// CreateBackupPolicy creates a new backup policy
+func CreateBackupPolicy(c *fiber.Ctx) error {
+	// Parse the request body
+	var body interfaces.BackupPolicy
+	if err := c.BodyParser(&body); err != nil {
+		slog.Error("Error parsing request body", "error", err)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	body.ConnectionID = c.Params("ConnID")
+
+	// Create the backup policy
+	backupPolicy, err := services.CreateBackUpPolicy(body)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	// Add the backup policy to the cron scheduler if it's active
+	if backupPolicy.Status == "Active" {
+		services.AddBackupToCron(backupPolicy.BackupPolicyID)
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"message":      "Backup policy created successfully",
+		"backupPolicy": backupPolicy,
+	})
+}
+
+// GetBackupPolicy gets a backup policy by ID
+func GetBackupPolicy(c *fiber.Ctx) error {
+	backupPolicyID := c.Params("BackupPolicyID")
+
+	backupPolicy, err := services.GetBackUpPolicy(backupPolicyID, nil)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Backup policy not found",
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"backupPolicy": backupPolicy,
+	})
+}
+
+// GetBackupPolicies gets all backup policies for a connection
+func GetBackupPolicies(c *fiber.Ctx) error {
+	connectionID := c.Params("ConnID")
+
+	backupPolicies, err := services.GetBackUpPolicies(services.GetBackUpPoliciesParams{
+		ConnectionID: &connectionID,
+		Status:       nil,
+	})
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"backupPolicies": backupPolicies,
+	})
+}
+
+// GetAllBackupPolicies gets all backup policies
+func GetAllBackupPolicies(c *fiber.Ctx) error {
+	backupPolicies, err := services.GetBackUpPolicies(services.GetBackUpPoliciesParams{
+		ConnectionID: nil,
+		Status:       nil,
+	})
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"backupPolicies": backupPolicies,
+	})
+}
+
+// UpdateBackupPolicy updates a backup policy
+func UpdateBackupPolicy(c *fiber.Ctx) error {
+	backupPolicyID := c.Params("BackupPolicyID")
+	connectionID := c.Params("ConnID")
+
+	// Get the existing backup policy
+	existingPolicy, err := services.GetBackUpPolicy(backupPolicyID, nil)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Backup policy not found",
+		})
+	}
+
+	// Parse the request body
+	var body interfaces.BackupPolicy
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	// Ensure the ID remains the same
+	body.BackupPolicyID = backupPolicyID
+	body.ConnectionID = connectionID
+
+	// Update the backup policy
+	updatedPolicy, err := services.UpdateBackUpPolicy(backupPolicyID, body)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+
+	// Handle cron job updates based on status changes
+	if existingPolicy.Status != updatedPolicy.Status {
+		if updatedPolicy.Status == "Active" {
+			services.AddBackupToCron(backupPolicyID)
+		} else {
+			services.RemoveBackupFromCron(backupPolicyID)
+		}
+	} else if updatedPolicy.Status == "Active" &&
+		(existingPolicy.Interval != updatedPolicy.Interval ||
+			existingPolicy.TimeUnit != updatedPolicy.TimeUnit) {
+		// If schedule changed but still active, update the cron job
+		services.RemoveBackupFromCron(backupPolicyID)
+		services.AddBackupToCron(backupPolicyID)
+	}
+
+	return c.JSON(fiber.Map{
+		"message":      "Backup policy updated successfully",
+		"backupPolicy": updatedPolicy,
+	})
+}
+
+// DeleteBackupPolicy deletes a backup policy
+func DeleteBackupPolicy(c *fiber.Ctx) error {
+	backupPolicyID := c.Params("BackupPolicyID")
+
+	// Delete the backup policy
+	deletedPolicy, err := services.DeleteBackUpPolicy(backupPolicyID)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Backup policy not found",
+		})
+	}
+
+	// Remove from cron scheduler
+	services.RemoveBackupFromCron(backupPolicyID)
+
+	return c.JSON(fiber.Map{
+		"message":      "Backup policy deleted successfully",
+		"backupPolicy": deletedPolicy,
+	})
+}
+
+// TriggerBackup manually triggers a backup for a policy
+func TriggerBackup(c *fiber.Ctx) error {
+	backupPolicyID := c.Params("BackupPolicyID")
+	connectionID := c.Params("ConnID")
+
+	// Check if the backup policy exists
+	_, err := services.GetBackUpPolicy(backupPolicyID, &connectionID)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Backup policy not found",
+		})
+	}
+
+	// Process the backup
+	isTriggered := true
+	go services.ProcessBackUp(backupPolicyID, &isTriggered)
+
+	return c.JSON(fiber.Map{
+		"message": "Backup process started",
+	})
+}
+
+// BackupsForPolicy gets all backups for a backup policy for a connection
+func BackupsForPolicy(c *fiber.Ctx) error {
+	backupPolicyID := c.Params("BackupPolicyID")
+	connectionID := c.Params("ConnID")
+
+	backups, err := services.GetBackUpLogs(backupPolicyID, connectionID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"backups": backups,
+	})
+}
+
+func BackupsForConnection(c *fiber.Ctx) error {
+	connectionID := c.Params("ConnID")
+
+	backups, err := services.GetAllLogs(connectionID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"backups": backups,
+	})
+}

--- a/src/controllers/backup.controller.go
+++ b/src/controllers/backup.controller.go
@@ -195,7 +195,7 @@ func BackupsForPolicy(c *fiber.Ctx) error {
 	backupPolicyID := c.Params("BackupPolicyID")
 	connectionID := c.Params("ConnID")
 
-	backups, err := services.GetBackUpLogs(backupPolicyID, connectionID)
+	backups, err := services.GetBackUpLogs(connectionID, backupPolicyID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": err.Error(),

--- a/src/controllers/restore.controller.go
+++ b/src/controllers/restore.controller.go
@@ -55,6 +55,49 @@ func RestoreSnapshot(
 
 }
 
+func RestoreBackup(
+	c *fiber.Ctx,
+) error {
+	connID := c.Params("ConnID")
+	backupID := c.Params("BackupID")
+	
+	type Request struct {
+		Database   string `json:"database"`
+		Collection string `json:"collection"`
+		Update     bool   `json:"update"`
+	}
+
+	body := new(Request)
+
+	if err := c.BodyParser(body); err != nil {
+		return err
+	}
+
+	err := services.RestoreBackup(
+		connID,
+		backupID,
+		"",
+		libs.FallBackString(
+			body.Database,
+			"",
+		),
+		libs.FallBackString(
+			body.Collection,
+			"",
+		),
+		body.Update,
+	)
+	if err != nil {
+		return c.JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"message": "Backup restored",
+	})
+}
+
 func GetRestores(
 	c *fiber.Ctx,
 ) error {

--- a/src/globals/database.go
+++ b/src/globals/database.go
@@ -10,13 +10,13 @@ import (
 )
 
 const (
-	ConnectionsCollection  = "connections"
-	SnapshotsCollection    = "snapshots"
-	UsersCollection        = "users"
-	RestoresCollection     = "restores"
-	StoragesCollection     = "storages"
-	BackupsCollection      = "backups"
-	BackupPolicyCollection = "backup-policy"
+	ConnectionsCollection    = "connections"
+	SnapshotsCollection      = "snapshots"
+	UsersCollection          = "users"
+	RestoresCollection       = "restores"
+	StoragesCollection       = "storages"
+	BackupsCollection        = "backups"
+	BackupPoliciesCollection = "backup-policies"
 )
 
 // Replace the placeholder with your Atlas connection string

--- a/src/interfaces/backup.interface.go
+++ b/src/interfaces/backup.interface.go
@@ -1,28 +1,53 @@
 package interfaces
 
 type BackupPolicy struct {
-	Interval     int    `json:"interval"`  // Frequency
-	TimeUnit     string `json:"timeUnit"`  // Time unit (minutes, hours, days)
-	Keep         int    `json:"keep"`      // Number of backups
-	Retention    int    `json:"retention"` // Number of days
-	Name         string `json:"name"`
-	Status       string `json:"status"`      // Active or Inactive
-	Compression  bool   `json:"compression"` // Compress backups
-	ConnectionID string `json:"connectionID"`
-	StorageID    string `json:"storageID"`
-	BackupID     string `json:"backupID"`
+	Interval       int    `json:"interval"`  // Frequency
+	TimeUnit       string `json:"timeUnit"`  // Time unit (minutes, hours, days)
+	Keep           int    `json:"keep"`      // Number of backups
+	Retention      int    `json:"retention"` // Number of days
+	Name           string `json:"name"`
+	Status         string `json:"status"`      // Active or Inactive
+	Compression    bool   `json:"compression"` // Compress backups
+	ConnectionID   string `json:"connectionID"`
+	StorageID      string `json:"storageID"`
+	BackupPolicyID string `json:"backupPolicyID"`
 
 	// Data Control
 	IsClusterBackup bool   `json:"isClusterBackup"`
 	Database        string `json:"database"`
 	Collection      string `json:"collection"`
+	IsDeleted       bool   `json:"isDeleted"`
+	NextRun         int64  `json:"nextRun"` // Unix timestamp of next run
 }
 
+// System Backup Logs
 type Backup struct {
-	BackupID  string `json:"backupID"`
-	Timestamp int64  `json:"timestamp"`
-	Status    string `json:"status"`
-	Logs      string `json:"logs"`
-	Duration  int64  `json:"duration"`
-	Size      int64  `json:"size"`
+	BackupID       string   `json:"backupID"`
+	Timestamp      int64    `json:"timestamp"`
+	Status         string   `json:"status"`
+	BackupPolicyID string   `json:"backupPolicyID"`
+	Logs           string   `json:"logs"`
+	Duration       int64    `json:"duration"`
+	Size           int64    `json:"size"`
+	Artifact       Artifact `json:"artifact"`
+	StorageID      string   `json:"storageID"`
+	IsDeleted      bool     `json:"isDeleted"`
+	ToBeDeletedAt  int64    `json:"toBeDeletedAt"` // Unix timestamp of deletion
+	IsTriggered    bool     `json:"isTriggered"`
+}
+
+
+type BackupWithPolicyName struct {
+	BackupID       string   `json:"backupID"`
+	Timestamp      int64    `json:"timestamp"`
+	Status         string   `json:"status"`
+	BackupPolicyID string   `json:"backupPolicyID"`
+	Logs           string   `json:"logs"`
+	Duration       int64    `json:"duration"`
+	Size           int64    `json:"size"`
+	Artifact       Artifact `json:"artifact"`
+	StorageID      string   `json:"storageID"`
+	IsDeleted      bool     `json:"isDeleted"`
+	ToBeDeletedAt  int64    `json:"toBeDeletedAt"` // Unix timestamp of deletion
+	PolicyName     string   `json:"policyName"`
 }

--- a/src/libs/cron.go
+++ b/src/libs/cron.go
@@ -1,0 +1,53 @@
+package libs
+
+import (
+	"fmt"
+	"strings"
+)
+
+type TimeUnit string
+
+const (
+	Second TimeUnit = "seconds"
+	Minute TimeUnit = "minutes"
+	Hour   TimeUnit = "hours"
+	Day    TimeUnit = "days"
+)
+
+func UnitToCron(value int, unit TimeUnit) (string, error) {
+	if value <= 0 {
+		return "", fmt.Errorf("value must be greater than 0")
+	}
+
+	unit = TimeUnit(strings.ToLower(string(unit)))
+
+	switch unit {
+	case Second:
+		// 6-field cron (requires scheduler with seconds support)
+		return fmt.Sprintf("*/%d * * * * *", value), nil
+	case Minute:
+		return fmt.Sprintf("0 */%d * * * *", value), nil
+	case Hour:
+		return fmt.Sprintf("0 */%d * * *", value), nil
+	case Day:
+		return fmt.Sprintf("0 0 */%d * *", value), nil
+	default:
+		return "", fmt.Errorf("unsupported time unit: %s", unit)
+	}
+}
+
+
+func ParseTimeUnitToMilli(unit TimeUnit) int64 {
+	switch unit {
+	case Second:
+		return 1_000
+	case Minute:
+		return 60 * 1_000
+	case Hour:
+		return 60 * 60 * 1_000
+	case Day:
+		return 24 * 60 * 60 * 1_000
+	default:
+		return 1_000 // Default to seconds
+	}
+}

--- a/src/libs/db.go
+++ b/src/libs/db.go
@@ -1,0 +1,22 @@
+package libs
+
+import (
+	"encoding/json"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+
+
+func MarshalWithJSONTags(v interface{}) (bson.M, error) {
+    // Convert to JSON first
+    jsonData, err := json.Marshal(v)
+    if err != nil {
+        return nil, err
+    }
+    
+    // Convert JSON to bson.M
+    var result bson.M
+    err = json.Unmarshal(jsonData, &result)
+    return result, err
+}

--- a/src/services/backup.service.go
+++ b/src/services/backup.service.go
@@ -1,1 +1,672 @@
 package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	global "mongostuff/src/globals"
+	"mongostuff/src/interfaces"
+	"mongostuff/src/libs"
+	"mongostuff/src/sdk"
+	"os"
+	"strconv"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// BackUp Policy CRUD
+func CreateBackUpPolicy(
+	params interfaces.BackupPolicy,
+) (interfaces.BackupPolicy, error) {
+
+	var Collection = global.GetCollection(global.BackupPoliciesCollection)
+
+	params.BackupPolicyID = libs.RandomString("backup_pol_", 12)
+
+	_, err := Collection.InsertOne(
+		context.TODO(),
+		bson.M{
+			"name":            params.Name,
+			"interval":        params.Interval,
+			"timeUnit":        params.TimeUnit,
+			"keep":            params.Keep,
+			"retention":       params.Retention,
+			"status":          params.Status,
+			"compression":     params.Compression,
+			"connectionID":    params.ConnectionID,
+			"storageID":       params.StorageID,
+			"backupPolicyID":  params.BackupPolicyID,
+			"isClusterBackup": params.IsClusterBackup,
+			"database":        params.Database,
+			"collection":      params.Collection,
+		},
+	)
+
+	if err != nil {
+		return interfaces.BackupPolicy{}, err
+	}
+
+	return params, nil
+}
+
+func GetBackUpPolicy(
+	backupPolicyID string,
+	connectionID *string,
+) (
+	interfaces.BackupPolicy,
+	error,
+) {
+	var Collection = global.GetCollection(global.BackupPoliciesCollection)
+
+	filter := bson.M{
+		"backupPolicyID": backupPolicyID,
+	}
+	if connectionID != nil {
+		filter["connectionID"] = *connectionID
+	}
+
+	backupPolicy := interfaces.BackupPolicy{}
+	err := Collection.FindOne(
+		context.TODO(),
+		filter,
+	).Decode(&backupPolicy)
+
+	if err != nil {
+		return interfaces.BackupPolicy{}, err
+	}
+
+	return backupPolicy, nil
+}
+
+type GetBackUpPoliciesParams struct {
+	ConnectionID *string
+	Status       *string
+}
+
+func GetBackUpPolicies(params GetBackUpPoliciesParams) (
+	[]interfaces.BackupPolicy,
+	error,
+) {
+	filter := bson.M{}
+	if params.ConnectionID != nil {
+		filter["connectionID"] = *params.ConnectionID
+	}
+	if params.Status != nil {
+		filter["status"] = *params.Status
+	}
+	var Collection = global.GetCollection(global.BackupPoliciesCollection)
+
+	backupPolicies := []interfaces.BackupPolicy{}
+	cursor, err := Collection.Find(
+		context.TODO(),
+		filter,
+	)
+	if err != nil {
+		return []interfaces.BackupPolicy{}, err
+	}
+	defer cursor.Close(context.TODO())
+	for cursor.Next(context.TODO()) {
+		var backupPolicy interfaces.BackupPolicy
+		err := cursor.Decode(&backupPolicy)
+		if err != nil {
+			return []interfaces.BackupPolicy{}, err
+		}
+		backupPolicies = append(backupPolicies, backupPolicy)
+	}
+
+	return backupPolicies, nil
+}
+
+func UpdateBackUpPolicy(
+	backupPolicyID string,
+	params interfaces.BackupPolicy,
+) (
+	interfaces.BackupPolicy,
+	error,
+) {
+	var Collection = global.GetCollection(global.BackupPoliciesCollection)
+
+	// Use custom marshaler
+    updateParams, err := libs.MarshalWithJSONTags(params)
+
+	backupPolicy := interfaces.BackupPolicy{}
+	err = Collection.FindOneAndUpdate(
+		context.TODO(),
+		bson.M{
+			"backupPolicyID": backupPolicyID,
+		},
+		bson.M{
+			"$set": updateParams,
+		},
+		options.FindOneAndUpdate().SetReturnDocument(options.After),
+	).Decode(&backupPolicy)
+
+	if err != nil {
+		return interfaces.BackupPolicy{}, err
+	}
+
+	return backupPolicy, nil
+}
+
+
+func UpdateBackUpPolicyNextRun(backupPolicyID string) {
+	var Collection = global.GetCollection(global.BackupPoliciesCollection)
+	
+	// First, get the backup policy to access its interval and timeUnit
+	backupPolicy, err := GetBackUpPolicy(backupPolicyID, nil)
+	if err != nil {
+		fmt.Println("Error getting backup policy for next run calculation")
+		fmt.Println(err)
+		return
+	}
+	
+	// Calculate next run time using the actual backup policy data
+	nextRun := time.Now().UnixMilli() + int64(backupPolicy.Interval)*libs.ParseTimeUnitToMilli(libs.TimeUnit(backupPolicy.TimeUnit))
+	
+	// Update the next run time
+	err = Collection.FindOneAndUpdate(
+		context.TODO(),
+		bson.M{
+			"backupPolicyID": backupPolicyID,
+		},
+		bson.M{
+			"$set": bson.M{
+				"nextRun": nextRun,
+			},
+		},
+	).Err()
+	if err != nil {
+		fmt.Println("Error updating backup policy next run")
+		fmt.Println(err)
+		return
+	}
+}
+
+func DeleteBackUpPolicy(
+	backupPolicyID string,
+) (
+	interfaces.BackupPolicy,
+	error,
+) {
+	var Collection = global.GetCollection(global.BackupPoliciesCollection)
+
+	backupPolicy := interfaces.BackupPolicy{}
+	err := Collection.FindOneAndUpdate(
+		context.TODO(),
+		bson.M{
+			"backupPolicyID": backupPolicyID,
+		},
+		bson.M{
+			"$set": bson.M{
+				"isDeleted": true,
+			},
+		},
+	).Decode(&backupPolicy)
+
+	if err != nil {
+		return interfaces.BackupPolicy{}, err
+	}
+
+	return backupPolicy, nil
+}
+
+// BackUp Retrieval Logs
+func GetBackUpLogs(
+	connectionID string,
+	backupPolicyID string,
+) (
+	[]interfaces.Backup,
+	error,
+) {
+	var Collection = global.GetCollection(global.BackupsCollection)
+
+	_, err := GetBackUpPolicy(backupPolicyID, &connectionID)
+	if err != nil {
+		return []interfaces.Backup{}, err
+	}
+
+	backups := []interfaces.Backup{}
+	cursor, err := Collection.Find(
+		context.TODO(),
+		bson.M{
+			"backupPolicyID": backupPolicyID,
+		},
+	)
+	if err != nil {
+		return []interfaces.Backup{}, err
+	}
+	defer cursor.Close(context.TODO())
+	for cursor.Next(context.TODO()) {
+		var backup interfaces.Backup
+		err := cursor.Decode(&backup)
+		if err != nil {
+			return []interfaces.Backup{}, err
+		}
+		backups = append(backups, backup)
+	}
+
+	return backups, nil
+}
+
+func GetAllLogs(
+	connectionID string,
+) (
+	[]interfaces.BackupWithPolicyName,
+	error,
+) {
+	fmt.Println("Getting all logs for connectionID", connectionID)
+	var Collection = global.GetCollection(global.BackupsCollection)
+	var BackupPolicyCollection = global.GetCollection(global.BackupPoliciesCollection)
+
+	// policyid for connectionID
+	backupPolicyIDs, err := BackupPolicyCollection.Distinct(
+		context.TODO(),
+		"backupPolicyID",
+		bson.M{
+			"connectionID": connectionID,
+		},
+	)
+	if err != nil {
+		return []interfaces.BackupWithPolicyName{}, err
+	}
+
+
+	backups := []interfaces.BackupWithPolicyName{}
+	cursor, err := Collection.Aggregate(
+		context.TODO(),
+		[]bson.M{
+			{
+				"$match": bson.M{
+					"backupPolicyID": bson.M{"$in": backupPolicyIDs},
+				},
+			},
+			{
+				"$lookup": bson.M{
+					"from": global.BackupPoliciesCollection,
+					"localField": "backupPolicyID",
+					"foreignField": "backupPolicyID",
+					"as": "backupPolicy",
+				},
+			},
+			{
+				"$addFields": bson.M{
+					"policyName": bson.M{"$arrayElemAt": bson.A{"$backupPolicy.name", 0}},
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		return []interfaces.BackupWithPolicyName{}, err
+	}
+	defer cursor.Close(context.TODO())
+	for cursor.Next(context.TODO()) {
+		var backup interfaces.BackupWithPolicyName
+		// print formatted json
+		err := cursor.Decode(&backup)
+		if err != nil {
+			return []interfaces.BackupWithPolicyName{}, err
+		}
+		backups = append(backups, backup)
+	}
+
+	return backups, nil
+}
+
+func GetBackup(backupID string) (interfaces.Backup, error) {
+	var Collection = global.GetCollection(global.BackupsCollection)
+	backup := interfaces.Backup{}
+	err := Collection.FindOne(
+		context.TODO(),
+		bson.M{"backupID": backupID},
+	).Decode(&backup)
+	if err != nil {
+		return interfaces.Backup{}, err
+	}
+	return backup, nil
+}
+
+// BackUp CRON & Process
+func AddBackupToCron(backupPolicyID string) {
+	fmt.Println("Adding backup policy to cron", backupPolicyID)
+	backupPolicy, err := GetBackUpPolicy(backupPolicyID, nil)
+	if err != nil {
+		fmt.Println("Error getting backup policy")
+		fmt.Println(err)
+		return
+	}
+
+	cronExpr, err := libs.UnitToCron(backupPolicy.Interval, libs.TimeUnit(backupPolicy.TimeUnit))
+	fmt.Printf("Cron Expression: %s\n", cronExpr)
+	if err != nil {
+		fmt.Println("Error converting time unit to cron expression")
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("Cron Expression: %s\n", cronExpr)
+	// add backup policy to cron
+	SCHEDULER.AddJob(backupPolicyID, cronExpr, func() {
+		fmt.Println("Running backup policy", backupPolicyID)
+		ProcessBackUp(backupPolicyID, nil)
+	})
+	if err != nil {
+		fmt.Println("Error adding backup policy to cron")
+		fmt.Println(err)
+		return
+	}
+}
+
+func RemoveBackupFromCron(backupPolicyID string) {
+	fmt.Println("Removing backup policy from cron", backupPolicyID)
+	// remove backup policy from cron
+	SCHEDULER.RemoveJob(backupPolicyID)
+}
+
+func InitCron() {
+	fmt.Println("Initializing cron")
+	// get all backup policies
+	backupPolicies, err := GetBackUpPolicies(GetBackUpPoliciesParams{
+		ConnectionID: nil,
+		Status:       nil,
+	})
+	if err != nil {
+		fmt.Println("Error getting backup policies")
+		fmt.Println(err)
+		return
+	}
+
+	// add backup policy to cron
+	for _, backupPolicy := range backupPolicies {
+		if backupPolicy.Status == "Active" {
+			AddBackupToCron(backupPolicy.BackupPolicyID)
+		}
+	}
+
+	fmt.Printf("Added %d backup policies to cron\n", len(backupPolicies))
+
+	// start cron
+	SCHEDULER.Start()
+
+	// add delete old backups to cron every day at 00:00
+	SCHEDULER.AddJob("delete_old_backups", "0 0 * * *", DeleteOldBackups)
+}
+
+func ProcessBackUp(backupPolicyID string, isTriggered *bool) {
+	backupPolicy, err := GetBackUpPolicy(backupPolicyID, nil)
+	fmt.Println("Backup Policy:==>", backupPolicy)
+	if err != nil {
+		return
+	}
+	outputFile := "./_stuffs/backups" + "/" + backupPolicy.BackupPolicyID + "_" + strconv.FormatInt(time.Now().Unix(), 10)
+
+	connection, err := GetConnection(backupPolicy.ConnectionID)
+
+	if err != nil {
+		fmt.Println("Error getting connection")
+		fmt.Println(err)
+		return
+	}
+
+	var BackUpCollection = global.GetCollection(global.BackupsCollection)
+
+	backupID := libs.RandomString("backup_", 16)
+
+	// Insert backup record
+	_, err = BackUpCollection.InsertOne(
+		context.TODO(),
+		bson.M{
+			"backupID":       backupID,
+			"backupPolicyID": backupPolicy.BackupPolicyID,
+			"timestamp":      time.Now().UnixMilli(),
+			"status":         "Running",
+			"logs":           "Backup process started",
+			"duration":       0,
+			"size":           0,
+			"artifact":       interfaces.Artifact{},
+			"storageID":      backupPolicy.StorageID,
+			"isTriggered":    isTriggered,
+		},
+	)
+
+	startTime := time.Now()
+
+	dumpRes := sdk.Dump(
+		sdk.MongoDump{
+			URI:         connection.URI,
+			Database:    backupPolicy.Database,
+			Collection:  backupPolicy.Collection,
+			OutputDir:   outputFile,
+			Compression: backupPolicy.Compression,
+		},
+	)
+
+	// End time
+	endTime := time.Now()
+	duration := endTime.Sub(startTime)
+
+	var status = func() string {
+		if dumpRes.ErrorStr != "" {
+			return "Failed"
+		}
+		return "Success"
+	}()
+
+	var size int64 = 0
+	if status != "Failed" {
+		fmt.Println("Calculating directory size", outputFile)
+		dirSize, err := libs.CalDirSize(outputFile)
+		if err != nil {
+			fmt.Println("Error calculating directory size")
+			fmt.Println(err)
+		}
+		size = dirSize.Size
+	}
+
+	slog.Info("Saving snapshot to storage")
+	var storageConfig interfaces.Storage
+
+	// When connection has DefaultStorageID, use it
+	if connection.DefaultStorageID != "" {
+		fmt.Println("Default storage ID:", connection.DefaultStorageID)
+		getStorage, err := GetStorage(
+			GetStorageParams{
+				StorageID: connection.DefaultStorageID,
+				UserID:    connection.UserID,
+			},
+		)
+		fmt.Println("Storage:==>", getStorage)
+		if err != nil {
+			fmt.Println("Error getting storage")
+			fmt.Println(err)
+			return
+		}
+		storageConfig = getStorage
+	}
+
+	//	If connection has no default storage ID, use the global default storage
+	if connection.DefaultStorageID == "" {
+		fmt.Println("No default storage ID")
+		defaultStorage, err := GetDefaultStorage(
+			GetDefaultStorageParams{
+				UserID: connection.UserID,
+			},
+		)
+		if err != nil {
+			fmt.Println("Error getting default storage")
+			fmt.Println(err)
+			return
+		}
+		storageConfig = defaultStorage
+	}
+
+	if err != nil {
+		fmt.Println("Error getting storage")
+		fmt.Println(err)
+		return
+	}
+
+	storageInstance := interfaces.Storage{
+		Type:      storageConfig.Type,
+		StorageID: storageConfig.StorageID,
+		Storage:   storageConfig.Storage,
+	}
+
+	fileBtes, err := os.ReadFile(outputFile)
+	if err != nil {
+		fmt.Println("Error reading file")
+		fmt.Println(err)
+		return
+	}
+
+	var ArtifactUnion interfaces.Artifact
+	if storageInstance.StorageID != "" {
+		artifact, err := storageInstance.UploadFile(
+			backupPolicy.BackupPolicyID+"_"+strconv.FormatInt(time.Now().Unix(), 10),
+			fileBtes,
+		)
+
+		if err != nil {
+			fmt.Println("Error uploading file")
+			fmt.Println(err)
+			return
+		}
+
+		ArtifactUnion = interfaces.Artifact{
+			URL:     artifact.URL,
+			Key:     artifact.Key,
+			Expires: artifact.Expires,
+		}
+
+		// Delete file
+		defer os.Remove(outputFile)
+
+	}
+
+	// Calculate to be deleted at Rentention is N of Days
+	toBeDeletedAt := time.Now().UnixMilli() + int64(backupPolicy.Retention)*24*60*60*1000 // Retention in milliseconds
+	// Save backup to DB
+	backup := interfaces.Backup{
+		BackupID:       backupID,
+		Timestamp:      time.Now().UnixMilli(),
+		Status:         status,
+		BackupPolicyID: backupPolicy.BackupPolicyID,
+		Logs:           libs.FallBackString(dumpRes.ErrorStr, dumpRes.Output),
+		Duration:       duration.Milliseconds(), // Duration in milliseconds,
+		Size:           size,
+		Artifact:       ArtifactUnion,
+		StorageID:      storageInstance.StorageID,
+		IsDeleted:      false,
+		ToBeDeletedAt:  toBeDeletedAt, // Retention in seconds
+	}
+
+
+
+	_, err = BackUpCollection.UpdateOne(
+		context.TODO(),
+		bson.M{
+			"backupID": backupID,
+		},
+		bson.M{
+			"$set": bson.M{
+				"status":        backup.Status,
+				"logs":          backup.Logs,
+				"duration":      backup.Duration,
+				"size":          backup.Size,
+				"artifact":      backup.Artifact,
+				"storageID":     backup.StorageID,
+				"toBeDeletedAt": backup.ToBeDeletedAt,
+			},
+		},
+	)
+	if err != nil {
+		fmt.Println("Error saving backup to DB")
+		fmt.Println(err)
+		return
+	}
+
+	if isTriggered == nil {
+		go UpdateBackUpPolicyNextRun(backupPolicyID)
+	}
+}
+
+
+func DeleteBackup(backupID string) {
+	var Collection = global.GetCollection(global.BackupsCollection)
+	// Get Backup
+	backup, err := GetBackup(backupID)
+	if err != nil {
+		fmt.Println("Error getting backup")
+		fmt.Println(err)
+		return
+	}
+
+	// Delete snapshot from storage
+	if backup.Artifact.Key != "" {
+		storage, err := GetStorage(
+			GetStorageParams{
+				StorageID: backup.StorageID,
+			},
+		)
+		if err != nil {
+			fmt.Println("Error getting storage")
+			fmt.Println(err)
+			return
+		}
+		err = storage.DeleteFile(backup.Artifact.Key)
+		if err != nil {
+			fmt.Println("Error deleting file")
+			fmt.Println(err)
+			return
+		}
+	}
+
+	// Delete backup from DB
+	_, err = Collection.DeleteOne(
+		context.TODO(),
+		bson.M{
+			"backupID": backupID,
+		},
+	)
+	if err != nil {
+		fmt.Println("Error deleting backup")
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("Backup deleted", backupID)
+}
+
+func DeleteOldBackups() {
+	var Collection = global.GetCollection(global.BackupsCollection)
+
+	// Only get backups that are past the retention date and select backupId
+	cursor, err := Collection.Find(
+		context.TODO(),
+		bson.M{
+			"toBeDeletedAt": bson.M{"$lt": time.Now().UnixMilli()},
+		},
+		&options.FindOptions{
+			Projection: bson.M{"backupID": 1},
+		},
+	)
+
+	if err != nil {
+		fmt.Println("Error getting backups")
+		fmt.Println(err)
+		return
+	}
+
+	for cursor.Next(context.TODO()) {
+		var backup interfaces.Backup
+		err := cursor.Decode(&backup)
+		if err != nil {
+			fmt.Println("Error decoding backup")
+			fmt.Println(err)
+			return
+		}
+		fmt.Println("Deleting backup", backup.BackupID)
+		DeleteBackup(backup.BackupID)
+	}
+}

--- a/src/services/restore.service.go
+++ b/src/services/restore.service.go
@@ -143,6 +143,131 @@ func RestoreSnapshot(
 	return nil
 }
 
+func RestoreBackup(
+	connectionID string,
+	backupID string,
+	sourceDatabase string,
+	targetDatabase string,
+	collection string,
+	update bool,
+) error {
+	var Collection = global.GetCollection(global.RestoresCollection)
+	backup, backup_err := GetBackup(backupID)
+	var backupPolicy interfaces.BackupPolicy
+	backupPolicy, backupPolicy_err := GetBackUpPolicy(backup.BackupPolicyID, nil)
+	if backupPolicy_err != nil {
+		return backupPolicy_err
+	}
+	connection, conn_err := GetConnection(connectionID)
+
+	if backup_err != nil {
+		return backup_err
+	}
+	if conn_err != nil {
+		return conn_err
+	}
+
+	fileName := backupID + "_" + strconv.FormatInt(backup.Timestamp, 10)
+	outputFile := "./_stuffs/backups" + "/" + fileName
+	if backup.StorageID != "" {
+		fmt.Println("StorageID: ", backup.StorageID)
+		storage, err := GetStorage(
+			GetStorageParams{
+				StorageID: backup.StorageID,
+			},
+		)
+		outputPath := outputFile
+		if backupPolicy.Compression {
+			outputPath += ".gz"
+		}
+		down, err := storage.DownloadFile(interfaces.ArtifactUnion(backup.Artifact), outputPath)
+		if err != nil {
+			return err
+		}
+
+		isExpired := down.Expires != nil && time.Now().Unix() > *backup.Artifact.Expires
+		// update snapshot with new url
+		if isExpired {
+			fmt.Println("URL expired, updating snapshot with new URL")
+			backup.Artifact.URL = down.URL
+			// update snapshot
+			_, err := Collection.UpdateOne(
+				context.TODO(),
+				bson.M{"backupID": backupID},
+				bson.M{"$set": bson.M{"artifact": backup.Artifact}},
+			)
+			if err != nil {
+				return err
+			}
+		}
+		fmt.Println("Downloaded file from storage")
+
+		defer os.Remove(outputPath)
+	}
+
+	// Calculate duration
+	startTime := time.Now()
+	restoreRes := sdk.Restore(
+		sdk.MongoRestore{
+			URI:            connection.URI,
+			SourceDatabase: libs.FallBackString(sourceDatabase, backupPolicy.Database),
+			TargetDatabase: libs.FallBackString(targetDatabase, ""),
+			Collection:     libs.FallBackString(collection, backupPolicy.Collection),
+			BackupPath:     outputFile,
+			IsCompress:     backupPolicy.Compression,
+			Update:         update || false,
+		},
+	)
+
+	endTime := time.Now()
+	duration := endTime.UnixMilli() - startTime.UnixMilli()
+
+	var status = func() string {
+		if restoreRes.ErrorStr != "" {
+			return "Failed"
+		}
+		return "Success"
+	}()
+
+	var restoreParams = interfaces.Restore{
+		Timestamp:               time.Now().UnixMilli(),
+		ConnectionID:            connectionID,
+		RestoreConnectionID:     connectionID,
+		BackupID:              backupID,
+		Logs:                    libs.FallBackString(restoreRes.ErrorStr, restoreRes.Output),
+		Status:                  status,
+		Duration:                duration,
+		Database:                libs.FallBackString(sourceDatabase, backupPolicy.Database),
+		TargetDatabase:          targetDatabase,
+		Collection:              collection,
+		RestoreID:               libs.RandomString("restore_", 12),
+		RestoreToDiffConnection: backupPolicy.ConnectionID != connectionID,
+	}
+
+	_, err := Collection.InsertOne(
+		context.TODO(),
+		bson.M{
+			"connectionID":            restoreParams.ConnectionID,
+			"restoreConnectionID":     restoreParams.RestoreConnectionID,
+			"backupID":              restoreParams.BackupID,
+			"database":                restoreParams.Database,
+			"targetDatabase":          restoreParams.TargetDatabase,
+			"collection":              restoreParams.Collection,
+			"timestamp":               restoreParams.Timestamp,
+			"status":                  restoreParams.Status,
+			"logs":                    restoreParams.Logs,
+			"duration":                restoreParams.Duration,
+			"restoreID":               restoreParams.RestoreID,
+			"restoreToDiffConnection": restoreParams.RestoreToDiffConnection,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func GetRestores(
 	connectionID string,
 ) interface{} {

--- a/src/services/scheduler.service.go
+++ b/src/services/scheduler.service.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/robfig/cron/v3"
+)
+
+type Scheduler struct {
+	cron *cron.Cron
+	jobs map[string]cron.EntryID // store by custom key (like userID or jobName)
+	mu   sync.Mutex
+}
+
+func NewScheduler() *Scheduler {
+	return &Scheduler{
+		cron: cron.New(cron.WithSeconds()),
+		jobs: make(map[string]cron.EntryID),
+	}
+}
+func (s *Scheduler) AddJob(key, spec string, cmd func()) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id, err := s.cron.AddFunc(spec, cmd)
+	if err != nil {
+		return err
+	}
+
+	s.jobs[key] = id
+	return nil
+}
+
+// Remove dynamic job
+func (s *Scheduler) RemoveJob(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if id, ok := s.jobs[key]; ok {
+		s.cron.Remove(id)
+		delete(s.jobs, key)
+	}
+}
+
+// List jobs
+func (s *Scheduler) ListJobs() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for key, id := range s.jobs {
+		entry := s.cron.Entry(id)
+		fmt.Printf("Job %s -> ID %d | Next: %s | Prev: %s\n",
+			key, id, entry.Next, entry.Prev)
+	}
+}
+
+func (s *Scheduler) Start() {
+	s.cron.Start()
+}
+
+var SCHEDULER = NewScheduler()

--- a/web/src/api/backup.ts
+++ b/web/src/api/backup.ts
@@ -1,0 +1,199 @@
+/**
+ * Backup API Handler Functions
+ *
+ * This file implements all API handler functions corresponding to the backup controller
+ * endpoints defined in src/controllers/backup.controller.go
+ *
+ * Implemented Functions:
+ * - CreateBackupPolicyRequest: Create a new backup policy
+ * - GetBackupPolicyRequest: Get a specific backup policy by ID
+ * - GetBackupPoliciesRequest: Get all backup policies for a connection
+ * - GetAllBackupPoliciesRequest: Get all backup policies (requires route)
+ * - UpdateBackupPolicyRequest: Update an existing backup policy
+ * - DeleteBackupPolicyRequest: Delete a backup policy
+ * - TriggerBackupRequest: Manually trigger a backup (requires route)
+ * - GetBackupsForPolicyRequest: Get all backups for a policy (requires route)
+ * - GetBackupsForConnectionRequest: Get all backups for a connection (requires route)
+ *
+ * Note: Some functions require additional routes to be added to main.go as indicated
+ * in the comments above each function.
+ */
+
+import { Delete, Get, Patch, Post, Put, TErrorResp } from ".";
+
+export type TBackupPolicy = {
+  interval: number;
+  timeUnit: string;
+  keep: number;
+  retention: number;
+  name: string;
+  status: string;
+  compression: boolean;
+  connectionID: string;
+  storageID: string;
+  backupPolicyID: string;
+  isClusterBackup: boolean;
+  database: string;
+  collection: string;
+  isDeleted: boolean;
+  nextRun: number;
+};
+
+export type TBackup = {
+  backupID: string;
+  timestamp: number;
+  status: string;
+  backupPolicyID: string;
+  logs: string;
+  duration: number;
+  size: number;
+  artifact: {
+    [key: string]: any;
+  };
+  storageID: string;
+  isDeleted: boolean;
+  toBeDeletedAt: number;
+  isTriggered: boolean;
+};
+
+export type TBackupWithPolicyName = TBackup & {
+  policyName: string;
+};
+
+const CreateBackupPolicyRequest = async (
+  connectionID: string,
+  policy: Omit<TBackupPolicy, "backupPolicyID" | "connectionID" | "isDeleted">
+) => {
+  const [response, error] = await Post<
+    Omit<TBackupPolicy, "backupPolicyID" | "connectionID" | "isDeleted">,
+    {
+      message: string;
+      backupPolicy: TBackupPolicy;
+    },
+    TErrorResp
+  >(`backup-policy/${connectionID}`, policy);
+  return { backupPolicy: response?.backupPolicy, error };
+};
+
+const GetBackupPolicyRequest = async (
+  connectionID: string,
+  backupPolicyID: string
+) => {
+  const [response, error] = await Get<
+    {
+      backupPolicy: TBackupPolicy;
+    },
+    TErrorResp
+  >(`backup-policy/${connectionID}/${backupPolicyID}`);
+  return { backupPolicy: response?.backupPolicy, error };
+};
+
+const GetBackupPoliciesRequest = async (connectionID: string) => {
+  const [response, error] = await Get<
+    {
+      backupPolicies: TBackupPolicy[];
+    },
+    TErrorResp
+  >(`backup-policy/${connectionID}`);
+  return { backupPolicies: response?.backupPolicies, error };
+};
+
+// Note: This endpoint is not currently routed in main.go
+// You may need to add: backupPolicyGroup.Get("/", controllers.GetAllBackupPolicies)
+const GetAllBackupPoliciesRequest = async () => {
+  const [response, error] = await Get<
+    {
+      backupPolicies: TBackupPolicy[];
+    },
+    TErrorResp
+  >(`backup-policy`);
+  return { backupPolicies: response?.backupPolicies, error };
+};
+
+const UpdateBackupPolicyRequest = async (
+  connectionID: string,
+  backupPolicyID: string,
+  policy: Partial<Omit<TBackupPolicy, "backupPolicyID" | "connectionID">>
+) => {
+  const [response, error] = await Patch<
+    Partial<Omit<TBackupPolicy, "backupPolicyID" | "connectionID">>,
+    {
+      message: string;
+      backupPolicy: TBackupPolicy;
+    },
+    TErrorResp
+  >(`backup-policy/${connectionID}/${backupPolicyID}`, policy);
+  return { backupPolicy: response?.backupPolicy, error };
+};
+
+const DeleteBackupPolicyRequest = async (
+  connectionID: string,
+  backupPolicyID: string
+) => {
+  const [response, error] = await Delete<
+    null,
+    {
+      message: string;
+      backupPolicy: TBackupPolicy;
+    },
+    TErrorResp
+  >(`backup-policy/${connectionID}/${backupPolicyID}`, null);
+  return { backupPolicy: response?.backupPolicy, error };
+};
+
+// Note: This endpoint is not currently routed in main.go
+// You may need to add: backupPolicyGroup.Post("/:ConnID/:BackupPolicyID/trigger", middlewares.IsConnectionBelongToUser, controllers.TriggerBackup)
+const TriggerBackupRequest = async (
+  connectionID: string,
+  backupPolicyID: string
+) => {
+  const [response, error] = await Put<
+    null,
+    {
+      message: string;
+    },
+    TErrorResp
+  >(`backup-policy/${connectionID}/${backupPolicyID}/trigger`, null);
+  return { message: response?.message, error };
+};
+
+// Note: This endpoint is not currently routed in main.go
+// You may need to add: backupPolicyGroup.Get("/:ConnID/:BackupPolicyID/backups", middlewares.IsConnectionBelongToUser, controllers.BackupsForPolicy)
+const GetBackupsForPolicyRequest = async (
+  connectionID: string,
+  backupPolicyID: string
+) => {
+  const [response, error] = await Get<
+    {
+      backups: TBackup[];
+    },
+    TErrorResp
+  >(`backup-policy/${connectionID}/${backupPolicyID}/backups`);
+  return { backups: response?.backups, error };
+};
+
+// Note: This endpoint is not currently routed in main.go
+// You may need to add a new backup group: backupGroup.Get("/:ConnID", middlewares.IsConnectionBelongToUser, controllers.BackupsForConnection)
+const GetBackupsForConnectionRequest = async (connectionID: string) => {
+  const [response, error] = await Get<
+    {
+      backups: TBackupWithPolicyName[];
+    },
+    TErrorResp
+  >(`backup/${connectionID}`);
+  return { backups: response?.backups, error };
+};
+
+const BackupAPI = {
+  CreateBackupPolicyRequest,
+  GetBackupPolicyRequest,
+  GetBackupPoliciesRequest,
+  GetAllBackupPoliciesRequest,
+  UpdateBackupPolicyRequest,
+  DeleteBackupPolicyRequest,
+  TriggerBackupRequest,
+  GetBackupsForPolicyRequest,
+  GetBackupsForConnectionRequest,
+};
+
+export default BackupAPI;

--- a/web/src/api/restore.ts
+++ b/web/src/api/restore.ts
@@ -49,7 +49,31 @@ export const RestoreSnapshot = async (params: {
       restore: TRestore;
       error: string;
     }
-  >(`restore/${connectionID}/${snapshotID}`, {
+  >(`restore/${connectionID}/${snapshotID}/snapshot`, {
+    database,
+    collection,
+    update,
+  });
+  return { restore, error };
+};
+
+export const RestoreBackup = async (params: {
+  connectionID: string;
+  backupID: string;
+  database?: string;
+  collection?: string;
+  update?: boolean;
+}) => {
+  const { connectionID, backupID, database, collection, update } = params;
+  const [restore, error] = await Post<
+    object,
+    TErrorResp,
+    {
+      message: string;
+      restore: TRestore;
+      error: string;
+    }
+  >(`restore/${connectionID}/${backupID}/backup`, {
     database,
     collection,
     update,
@@ -61,6 +85,7 @@ const RestoreAPI = {
   ListRestoreRequest,
   GetRestoreRequest,
   RestoreSnapshot,
+  RestoreBackup,
 };
 
 export default RestoreAPI;

--- a/web/src/pages/connections/connectionTabs.tsx
+++ b/web/src/pages/connections/connectionTabs.tsx
@@ -4,13 +4,20 @@ import {
   DatabaseBackup,
   HardDrive,
   LayoutDashboard,
+  Scroll,
   Settings,
 } from "lucide-react";
 // import { GalleryIcon } from "./GalleryIcon";
 // import { MusicIcon } from "./MusicIcon";
 // import { VideoIcon } from "./VideoIcon";
 
-type Pages = "Overview" | "Snapshots" | "Backups" | "Restores" | "Settings";
+type Pages =
+  | "Overview"
+  | "Snapshots"
+  | "BackupsPolicies"
+  | "Backups"
+  | "Restores"
+  | "Settings";
 type Props = {
   Pages: {
     [K in Pages]: React.FC;
@@ -53,6 +60,17 @@ export default function ConnectionTabs(props: Props) {
           }
         >
           <props.Pages.Snapshots />
+        </Tab>
+        <Tab
+          key="backups-policies"
+          title={
+            <div className="flex items-center space-x-2">
+              <Scroll size={18} />
+              <span>Backups Policies</span>
+            </div>
+          }
+        >
+          <props.Pages.BackupsPolicies />
         </Tab>
         <Tab
           key="backups"

--- a/web/src/pages/connections/connectionView.tsx
+++ b/web/src/pages/connections/connectionView.tsx
@@ -7,6 +7,7 @@ import ConnectionSettings from "./tabs/settings";
 import ConnectionSnapshots from "./tabs/snapshots";
 import { useConnectionStore } from "../../stores/connection.store";
 import { useParams } from "react-router-dom";
+import ConnectionBackupPolicies from "./tabs/backup-policies";
 
 export type Props = {
   ConnectionID: string;
@@ -23,6 +24,7 @@ export default function ConnectionFullView() {
         Pages={{
           Overview: ConnectionOverview,
           Snapshots: ConnectionSnapshots,
+          BackupsPolicies: ConnectionBackupPolicies,
           Backups: ConnectionBackups,
           Restores: ConnectionRestores,
           Settings: ConnectionSettings,

--- a/web/src/pages/connections/connections.tsx
+++ b/web/src/pages/connections/connections.tsx
@@ -4,7 +4,8 @@ import {
   Button,
   Card,
   CardBody,
-  CardHeader,
+  Chip,
+  Divider,
   Input,
   Modal,
   ModalBody,
@@ -14,7 +15,6 @@ import {
   Tooltip,
   useDisclosure,
 } from "@heroui/react";
-import { DotLottieReact } from "@lottiefiles/dotlottie-react";
 import {
   Activity,
   ArrowRight,
@@ -22,12 +22,14 @@ import {
   LinkIcon,
   Pen,
   Plus,
+  Server,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import ConnectionAPI, { TConnection } from "../../api/connection";
-import EmptyState from "../../components/emptyState";
 import { useConnectionStore } from "../../stores/connection.store";
+import { DotLottieReact } from "@lottiefiles/dotlottie-react";
+import EmptyState from "../../components/emptyState";
 
 export function ConnectionCard(props: TConnection) {
   const getDatabaseCount = () => {
@@ -46,113 +48,95 @@ export function ConnectionCard(props: TConnection) {
   return (
     <Card
       isPressable
-      className="group relative overflow-hidden h-full flex flex-col w-full hover:-translate-y-1 transition-all duration-300 ease-out"
+      className="group relative overflow-hidden h-full flex flex-col w-full hover:-translate-y-2 transition-all duration-500 ease-out"
       shadow="sm"
       classNames={{
-        base: "bg-content1 border-divider hover:border-primary hover:shadow-primary/20",
-        body: "p-3 sm:p-4",
-        header: "pb-2",
+        base: "bg-gradient-to-br from-background/80 to-background/60 border border-default-200/50 hover:border-primary/50 hover:shadow-xl hover:shadow-primary/10 backdrop-blur-sm",
+        body: "p-0",
+        header: "p-0",
       }}
     >
       <Link
         to={`/connection/${props.connectionID}`}
-        className="block h-full flex flex-col"
+        className="block h-full flex flex-col w-full"
       >
-        {/* Status indicator */}
-        <div className="absolute top-3 right-3 z-10">
-          <div className="w-3 h-3 rounded-full bg-primary animate-pulse border-2 border-content1 shadow-small" />
-        </div>
-
-        {/* Header with enhanced styling */}
-        <CardHeader className="flex gap-3 sm:gap-4 pb-2">
-          <div className="relative flex-shrink-0 flex items-center gap-2">
+        {/* Compact Header */}
+        <div className="relative p-4">
+          {/* Connection info - compact */}
+          <div className="flex items-center gap-3">
             <Avatar
               isBordered
               name={props.name.slice(0, 2).toUpperCase()}
               size="md"
-              className="group-hover:scale-110 transition-transform duration-300 bg-primary-50"
+              className="group-hover:scale-105 transition-transform duration-300"
             />
-            <h3 className="text-base sm:text-lg font-semibold group-hover:text-primary-foreground transition-colors duration-200 truncate">
+            <h3 className="text-base font-semibold text-foreground group-hover:text-primary transition-colors duration-200 truncate">
               {props.name}
             </h3>
           </div>
-        </CardHeader>
+        </div>
 
-        {/* Enhanced body with statistics */}
-        <CardBody className="pt-0 flex-grow flex flex-col">
-          <div className="space-y-4 flex-grow">
-            {/* Database and Collection stats */}
-            <div className="grid grid-cols-2 gap-2 sm:gap-3">
-              <div className="flex items-center gap-1.5 sm:gap-2 p-1.5 sm:p-2 rounded-medium bg-primary/10 group-hover:bg-primary/20 transition-colors duration-200 border border-primary/20">
-                <Database
-                  size={14}
-                  className="sm:w-4 sm:h-4 text-primary flex-shrink-0"
-                />
-                <div className="flex flex-col min-w-0">
-                  <span className="text-xs text-primary truncate font-medium">
-                    Databases
-                  </span>
-                  <span className="text-sm font-bold text-foreground">
-                    {getDatabaseCount()}
-                  </span>
-                </div>
-              </div>
-              <div className="flex items-center gap-1.5 sm:gap-2 p-1.5 sm:p-2 rounded-medium bg-primary/10 group-hover:bg-primary/20 transition-colors duration-200 border border-primary/20">
-                <Activity
-                  size={14}
-                  className="sm:w-4 sm:h-4 text-primary flex-shrink-0"
-                />
-                <div className="flex flex-col min-w-0">
-                  <span className="text-xs text-primary truncate font-medium">
-                    Collections
-                  </span>
-                  <span className="text-sm font-bold text-foreground">
-                    {getCollectionCount()}
-                  </span>
-                </div>
+        {/* Compact Stats section */}
+        <div className="w-full px-4">
+          <div className="grid grid-cols-2 gap-3 mb-3 w-full">
+            <div className="flex items-center gap-2 p-2 rounded-lg bg-content2/50 border border-divider group-hover:bg-content2 transition-colors duration-200">
+              <Database className="w-4 h-4 text-primary" />
+              <div className="flex flex-col items-start">
+                <p className="text-xs text-default-500">Databases</p>
+                <p className="text-md font-semibold text-foreground">
+                  {getDatabaseCount()}
+                </p>
               </div>
             </div>
 
-            {/* Database avatars with improved styling */}
-            {props?.databases && props.databases.length > 0 && (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-medium text-primary uppercase tracking-wide">
-                    Recent Databases
-                  </span>
-                  <ArrowRight
-                    size={12}
-                    className="sm:w-3.5 sm:h-3.5 text-primary group-hover:text-primary-foreground group-hover:translate-x-1 transition-all duration-200"
-                  />
-                </div>
-                <AvatarGroup isBordered max={3} className="justify-start px-2">
-                  {props.databases.slice(0, 3).map((db, index) => (
-                    <Tooltip
-                      key={index}
-                      content={db}
-                      placement="top"
-                      showArrow
-                      classNames={{
-                        content: "bg-default-900 text-default-50",
-                      }}
-                    >
+            <div className="flex items-center gap-2 p-2 rounded-lg bg-content2/50 border border-divider group-hover:bg-content2 transition-colors duration-200">
+              <Activity className="w-4 h-4 text-primary" />
+              <div className="flex flex-col items-start">
+                <p className="text-xs text-default-500">Collections</p>
+                <p className="text-md font-semibold text-foreground">
+                  {getCollectionCount()}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Compact Database preview */}
+          {props?.databases && props.databases.length > 0 && (
+            <div className="space-y-2 p-2 mb-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-default-500 uppercase tracking-wide">
+                  Databases
+                </span>
+                <ArrowRight
+                  size={12}
+                  className="text-primary group-hover:translate-x-1 transition-all duration-200"
+                />
+              </div>
+              <div className="flex items-center gap-1 ml-2">
+                <AvatarGroup isBordered max={6} className="justify-start">
+                  {props.databases.slice(0, 6).map((db, index) => (
+                    <Tooltip key={index} content={db} placement="top" showArrow>
                       <Avatar
                         isBordered
                         name={db[0].toUpperCase()}
                         size="sm"
-                        color="default"
-                        className="w-6 h-6 sm:w-8 sm:h-8 hover:scale-110 transition-transform duration-200 text-xs sm:text-sm"
+                        className="w-6 h-6 hover:scale-105 transition-transform duration-200 text-xs"
                       />
                     </Tooltip>
                   ))}
                 </AvatarGroup>
+                {props.databases.length > 3 && (
+                  <Chip size="sm" variant="flat" className="text-xs">
+                    +{props.databases.length - 3}
+                  </Chip>
+                )}
               </div>
-            )}
-          </div>
-        </CardBody>
+            </div>
+          )}
+        </div>
 
-        {/* Subtle hover effect overlay */}
-        <div className="absolute inset-0 bg-gradient-to-r from-primary/0 via-primary/0 to-primary/0 group-hover:from-primary/5 group-hover:via-primary/10 group-hover:to-primary/5 transition-all duration-300 pointer-events-none" />
+        {/* Hover effect overlay */}
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/0 via-primary/0 to-primary/0 group-hover:from-primary/5 group-hover:via-primary/10 group-hover:to-primary/5 transition-all duration-500 pointer-events-none rounded-lg" />
       </Link>
     </Card>
   );
@@ -184,65 +168,128 @@ export function CreateConnectionModal(props: { RunOnSubmit: () => void }) {
     props.RunOnSubmit();
     setIsLoading(false);
   };
+
   return (
     <>
       <Button
-        className="shadow-lg bg-primary-50"
-        size="sm"
+        size="md"
         startContent={
           !isLoading && <Plus size={18} className="sm:w-5 sm:h-5" />
         }
-        variant="shadow"
+        variant="solid"
         onPress={onOpen}
         isLoading={isLoading}
+        className="bg-primary-50 text-white hover:bg-primary-600"
       >
-        <span className="text-sm sm:text-base font-medium">Add Connection</span>
+        <span className="text-sm sm:text-base font-semibold">
+          Add Connection
+        </span>
       </Button>
-      <Modal isOpen={isOpen} onOpenChange={onOpenChange} placement="top-center">
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        placement="top-center"
+        size="lg"
+        classNames={{
+          base: "bg-background/95 backdrop-blur-md",
+          header: "border-b border-divider",
+          body: "py-6",
+          footer: "border-t border-divider",
+        }}
+      >
         <ModalContent>
           {(onClose) => (
             <>
-              <ModalHeader className="flex flex-col gap-1">
-                Add Connection
+              <ModalHeader className="flex flex-col gap-1 pb-4">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-content2 rounded-lg">
+                    <Server className="w-5 h-5 text-primary" />
+                  </div>
+                  <div>
+                    <h2 className="text-xl font-bold text-foreground">
+                      Add New Connection
+                    </h2>
+                    <p className="text-sm text-default-500">
+                      Connect to your MongoDB database
+                    </p>
+                  </div>
+                </div>
               </ModalHeader>
-              <ModalBody>
-                <Input
-                  autoFocus
-                  endContent={
-                    <LinkIcon
-                      size={20}
-                      className="flex-shrink-0 pointer-events-none text-md text-default-400"
+              <Divider />
+              <ModalBody className="pt-6">
+                <div className="space-y-6">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium text-foreground">
+                      Connection URI
+                    </label>
+                    <Input
+                      autoFocus
+                      endContent={
+                        <LinkIcon
+                          size={20}
+                          className="flex-shrink-0 pointer-events-none text-default-400"
+                        />
+                      }
+                      placeholder="mongodb://username:password@host:port/database"
+                      variant="bordered"
+                      value={connectionURI}
+                      onChange={(e) => setConnectionURI(e.target.value)}
+                      classNames={{
+                        input: "font-mono text-sm",
+                        inputWrapper:
+                          "border-default-200 hover:border-primary-300 focus-within:border-primary-500",
+                      }}
                     />
-                  }
-                  label="URI"
-                  placeholder="Connection URI with username and password"
-                  variant="bordered"
-                  onChange={(e) => setConnectionURI(e.target.value)}
-                />
-                <Input
-                  endContent={
-                    <Pen
-                      size={20}
-                      className="flex-shrink-0 pointer-events-none text-default-400"
-                    />
-                  }
-                  label="Name"
-                  placeholder="Enter a name for this connection"
-                  variant="bordered"
-                  onChange={(e) => setConnectionName(e.target.value)}
-                />
-              </ModalBody>
-              <ModalFooter>
-                <Button color="danger" variant="flat" onPress={onClose}>
-                  Close
-                </Button>
+                    <p className="text-xs text-default-400">
+                      Include your username, password, and database details in
+                      the URI
+                    </p>
+                  </div>
 
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium text-foreground">
+                      Connection Name
+                    </label>
+                    <Input
+                      endContent={
+                        <Pen
+                          size={20}
+                          className="flex-shrink-0 pointer-events-none text-default-400"
+                        />
+                      }
+                      placeholder="My Production Database"
+                      variant="bordered"
+                      value={connectionName}
+                      onChange={(e) => setConnectionName(e.target.value)}
+                      classNames={{
+                        inputWrapper:
+                          "border-default-200 hover:border-primary-300 focus-within:border-primary-500",
+                      }}
+                    />
+                    <p className="text-xs text-default-400">
+                      Choose a descriptive name for easy identification
+                    </p>
+                  </div>
+                </div>
+              </ModalBody>
+              <Divider />
+              <ModalFooter className="pt-4">
+                <Button
+                  color="default"
+                  variant="flat"
+                  onPress={onClose}
+                  className="font-medium"
+                >
+                  Cancel
+                </Button>
                 <Button
                   color="primary"
                   onPress={handleAddConnection}
                   isLoading={isLoading}
+                  className="font-semibold"
+                  isDisabled={!connectionURI.trim() || !connectionName.trim()}
                 >
-                  Save
+                  {isLoading ? "Connecting..." : "Create Connection"}
                 </Button>
               </ModalFooter>
             </>
@@ -260,45 +307,130 @@ export default function Connections() {
     getConnections();
   }, []);
 
+  const totalDatabases = connectionList.reduce(
+    (total, conn) => total + (conn.databases?.length || 0),
+    0
+  );
+  const totalCollections = connectionList.reduce(
+    (total, conn) =>
+      total +
+      (conn.collections?.reduce(
+        (dbTotal, db) => dbTotal + db.collections.length,
+        0
+      ) || 0),
+    0
+  );
+
   return (
-    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-xl sm:text-2xl font-bold">Connections</h1>
-        </div>
-        <CreateConnectionModal RunOnSubmit={getConnections} />
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 md:gap-6">
-        {connectionList.map((connection, index) => (
-          <div
-            key={index}
-            className="animate-in fade-in-0 slide-in-from-bottom-4 duration-500 h-full"
-            style={{ animationDelay: `${index * 100}ms` }}
-          >
-            <ConnectionCard {...connection} />
+    <div className="min-h-screen bg-background">
+      <div className="p-4 sm:p-6 space-y-6 sm:space-y-8">
+        {/* Enhanced Header */}
+        <div className="relative">
+          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+            <div className="space-y-2">
+              <div className="flex items-center gap-3">
+                <div className="p-3 bg-content2 rounded-xl">
+                  <Server className="w-6 h-6 text-primary" />
+                </div>
+                <div>
+                  <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
+                    Database Connections
+                  </h1>
+                  <p className="text-sm text-default-500">
+                    Manage your MongoDB connections and monitor their status
+                  </p>
+                </div>
+              </div>
+            </div>
+            <CreateConnectionModal RunOnSubmit={getConnections} />
           </div>
-        ))}
-      </div>
-      {connectionList?.length === 0 && (
-        <div>
-          <div className="flex flex-col items-center justify-center h-60 sm:h-80 px-4">
-            <EmptyState
-              Icon={
-                <DotLottieReact
-                  src="https://lottie.host/281813e4-12ea-4257-a041-69fc069edafe/dQopTPxL06.lottie"
-                  loop
-                  autoplay
-                  backgroundColor="transparent"
-                />
-              }
-              Title="Nothing to see here....."
-              Description="Add New Connection to see something here bruh!, meanwhile let me sleep."
-              TitleClassName="-translate-y-16 sm:-translate-y-20"
-              DescriptionClassName="-translate-y-16 sm:-translate-y-20"
-            />
-          </div>
+
+          {/* Stats Overview */}
+          {connectionList.length > 0 && (
+            <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <Card className="border border-divider bg-content1">
+                <CardBody className="flex flex-row items-center gap-3 p-4">
+                  <div className="p-2 bg-content2 rounded-lg">
+                    <Server className="w-5 h-5 text-primary" />
+                  </div>
+                  <div>
+                    <p className="text-sm text-default-500">
+                      Active Connections
+                    </p>
+                    <p className="text-xl font-bold text-foreground">
+                      {connectionList.length}
+                    </p>
+                  </div>
+                </CardBody>
+              </Card>
+
+              <Card className="border border-divider bg-content1">
+                <CardBody className="flex flex-row items-center gap-3 p-4">
+                  <div className="p-2 bg-content2 rounded-lg">
+                    <Database className="w-5 h-5 text-primary" />
+                  </div>
+                  <div>
+                    <p className="text-sm text-default-500">Total Databases</p>
+                    <p className="text-xl font-bold text-foreground">
+                      {totalDatabases}
+                    </p>
+                  </div>
+                </CardBody>
+              </Card>
+
+              <Card className="border border-divider bg-content1">
+                <CardBody className="flex flex-row items-center gap-3 p-4">
+                  <div className="p-2 bg-content2 rounded-lg">
+                    <Activity className="w-5 h-5 text-primary" />
+                  </div>
+                  <div>
+                    <p className="text-sm text-default-500">
+                      Total Collections
+                    </p>
+                    <p className="text-xl font-bold text-foreground">
+                      {totalCollections}
+                    </p>
+                  </div>
+                </CardBody>
+              </Card>
+            </div>
+          )}
         </div>
-      )}
+
+        {/* Connections Grid */}
+        {connectionList?.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6">
+            {connectionList.map((connection, index) => (
+              <div
+                key={index}
+                className="animate-in fade-in-0 slide-in-from-bottom-4 duration-700 h-full"
+                style={{ animationDelay: `${index * 150}ms` }}
+              >
+                <ConnectionCard {...connection} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div>
+            <div className="flex flex-col items-center justify-center h-60 sm:h-80 px-4">
+              <EmptyState
+                Icon={
+                  <DotLottieReact
+                    src="https://lottie.host/281813e4-12ea-4257-a041-69fc069edafe/dQopTPxL06.lottie"
+                    loop
+                    autoplay
+                    backgroundColor="transparent"
+                  />
+                }
+                Title="Nothing to see here....."
+                Description="Add New Connection to see something here bruh!, meanwhile let me sleep."
+                TitleClassName="-translate-y-16 sm:-translate-y-20"
+                DescriptionClassName="-translate-y-16 sm:-translate-y-20"
+              />
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/pages/connections/tabs/backup-policies.tsx
+++ b/web/src/pages/connections/tabs/backup-policies.tsx
@@ -1,0 +1,792 @@
+import {
+  Button,
+  Chip,
+  Divider,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Pagination,
+  Select,
+  SelectItem,
+  Spacer,
+  Spinner,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  useDisclosure,
+} from "@heroui/react";
+import { DotLottieReact } from "@lottiefiles/dotlottie-react";
+import React, { useEffect, useState } from "react";
+import { TBackupPolicy } from "../../../api/backup";
+
+import {
+  Boxes,
+  Calendar,
+  Clock,
+  Database,
+  HardDrive,
+  Pencil,
+  Play,
+  Plus,
+  Settings,
+  Shrink,
+  Star,
+  Trash,
+  Zap,
+} from "lucide-react";
+import { useParams } from "react-router-dom";
+import { toast } from "sonner";
+import EmptyState from "../../../components/emptyState";
+import { useBackupStore } from "../../../stores/backup.store";
+import { useConnectionStore } from "../../../stores/connection.store";
+import { useStorageStore } from "../../../stores/storage.store";
+
+// Create/Edit Backup Policy Modal
+export function CreateBackupPolicyModal({
+  editPolicy,
+  onClose,
+}: {
+  editPolicy?: TBackupPolicy;
+  onClose?: () => void;
+}) {
+  const { connection } = useConnectionStore();
+  const { storageList, getStorages } = useStorageStore();
+  const { createBackupPolicy, updateBackupPolicy, isCreating, isUpdating } =
+    useBackupStore();
+  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+
+  const [name, setName] = useState(editPolicy?.name || "");
+  const [interval, setInterval] = useState(editPolicy?.interval || 1);
+  const [timeUnit, setTimeUnit] = useState(editPolicy?.timeUnit || "hours");
+  const [keep, setKeep] = useState(editPolicy?.keep || 5);
+  const [retention, setRetention] = useState(editPolicy?.retention || 30);
+  const [status, setStatus] = useState(editPolicy?.status || "Active");
+  const [compression, setCompression] = useState(
+    editPolicy?.compression ?? true
+  );
+  const [storageID, setStorageID] = useState<Set<string>>(
+    new Set([connection?.defaultStorageID!])
+  );
+  const [isClusterBackup, setIsClusterBackup] = useState(
+    editPolicy?.isClusterBackup ?? false
+  );
+  const [database, setDatabase] = useState(editPolicy?.database || "");
+  const [collection, setCollection] = useState(editPolicy?.collection || "");
+
+  useEffect(() => {
+    if (isOpen) {
+      getStorages();
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async () => {
+    if (!name.trim()) {
+      toast.error("Policy name is required");
+      return;
+    }
+
+    if (!storageID) {
+      toast.error("Storage selection is required");
+      return;
+    }
+
+    const policyData = {
+      name: name.trim(),
+      interval,
+      timeUnit,
+      keep,
+      retention,
+      status,
+      compression,
+      storageID: Array.from(storageID)[0],
+      isClusterBackup,
+      database: isClusterBackup ? "" : database,
+      collection: isClusterBackup ? "" : collection,
+      nextRun: 0, // Will be calculated by the backend
+    };
+
+    let success = false;
+    if (editPolicy) {
+      success = await updateBackupPolicy(
+        connection?.connectionID as string,
+        editPolicy.backupPolicyID,
+        policyData
+      );
+    } else {
+      success = await createBackupPolicy(
+        connection?.connectionID ?? "",
+        policyData
+      );
+    }
+
+    if (success) {
+      onOpenChange();
+      onClose?.();
+      // Reset form
+      setName("");
+      setInterval(1);
+      setTimeUnit("hours");
+      setKeep(5);
+      setRetention(30);
+      setStatus("Active");
+      setCompression(true);
+      setStorageID(new Set([connection?.defaultStorageID!]));
+      setIsClusterBackup(true);
+      setDatabase("");
+      setCollection("");
+    }
+  };
+
+  const timeUnits = [
+    { key: "minutes", label: "Minutes" },
+    { key: "hours", label: "Hours" },
+    { key: "days", label: "Days" },
+  ];
+
+  const statusOptions = [
+    { key: "Active", label: "Active" },
+    { key: "Inactive", label: "Inactive" },
+  ];
+
+  return (
+    <>
+      {!editPolicy && (
+        <Button
+          className="shadow-lg bg-primary-50"
+          size="sm"
+          startContent={!isCreating && <Plus size={20} />}
+          variant="shadow"
+          onPress={onOpen}
+          isLoading={isCreating}
+        >
+          {isCreating ? "Creating Policy" : "Create Policy"}
+        </Button>
+      )}
+
+      {editPolicy && (
+        <Tooltip content="Edit Policy">
+          <span
+            className="text-lg cursor-pointer active:opacity-50"
+            onClick={onOpen}
+          >
+            <Pencil size={20} className="text-blue-500" />
+          </span>
+        </Tooltip>
+      )}
+
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        placement="top-center"
+        size="2xl"
+        scrollBehavior="inside"
+        className="max-h-[95vh]"
+      >
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-col gap-1">
+                {editPolicy ? "Edit Backup Policy" : "Create Backup Policy"}
+              </ModalHeader>
+              <ModalBody className="flex flex-col gap-4">
+                {/* Basic Information */}
+                <div className="flex flex-col gap-4">
+                  <h3 className="text-lg font-semibold flex items-center gap-2">
+                    <Settings size={20} />
+                    Basic Information
+                  </h3>
+
+                  <Input
+                    label="Policy Name"
+                    placeholder="Enter backup policy name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    isRequired
+                  />
+
+                  <div className="flex gap-4">
+                    <Input
+                      label="Interval"
+                      type="number"
+                      min="1"
+                      value={interval.toString()}
+                      onChange={(e) =>
+                        setInterval(parseInt(e.target.value) || 1)
+                      }
+                      className="flex-1"
+                    />
+                    <Select
+                      label="Time Unit"
+                      selectedKeys={[timeUnit]}
+                      onSelectionChange={(keys) => {
+                        const selectedKey = Array.from(keys)[0] as string;
+                        setTimeUnit(selectedKey);
+                      }}
+                      className="flex-1"
+                    >
+                      {timeUnits.map((unit) => (
+                        <SelectItem key={unit.key}>{unit.label}</SelectItem>
+                      ))}
+                    </Select>
+                  </div>
+
+                  <div className="flex gap-4">
+                    <Input
+                      label="Keep Backups"
+                      type="number"
+                      min="1"
+                      value={keep.toString()}
+                      onChange={(e) => setKeep(parseInt(e.target.value) || 1)}
+                      className="flex-1"
+                      description="Number of backups to keep"
+                    />
+                    <Input
+                      label="Retention (Days)"
+                      type="number"
+                      min="1"
+                      value={retention.toString()}
+                      onChange={(e) =>
+                        setRetention(parseInt(e.target.value) || 1)
+                      }
+                      className="flex-1"
+                      description="Days to keep backups"
+                    />
+                  </div>
+
+                  <Select
+                    label="Status"
+                    selectedKeys={[status]}
+                    onSelectionChange={(keys) => {
+                      const selectedKey = Array.from(keys)[0] as string;
+                      setStatus(selectedKey);
+                    }}
+                  >
+                    {statusOptions.map((option) => (
+                      <SelectItem key={option.key}>{option.label}</SelectItem>
+                    ))}
+                  </Select>
+                </div>
+
+                <Divider />
+
+                {/* Storage Configuration */}
+                <div className="flex flex-col gap-4">
+                  <h3 className="text-lg font-semibold flex items-center gap-2">
+                    <HardDrive size={20} />
+                    Storage Configuration
+                  </h3>
+
+                  <Select
+                    label="Storage"
+                    placeholder="Select storage for backups"
+                    selectedKeys={storageID}
+                    onSelectionChange={setStorageID as any}
+                    isRequired
+                    endContent={
+                      Array.from(storageID).includes(
+                        connection?.defaultStorageID!
+                      ) ? (
+                        <Chip
+                          size="sm"
+                          variant="flat"
+                          color="success"
+                          startContent={<Star size={12} />}
+                        >
+                          Default
+                        </Chip>
+                      ) : null
+                    }
+                  >
+                    {storageList.map((storage) => (
+                      <SelectItem key={storage.storageID}>
+                        {storage.name}
+                      </SelectItem>
+                    ))}
+                  </Select>
+
+                  <div className="flex items-center justify-between">
+                    <div className="flex gap-2">
+                      <Shrink size={20} />
+                      <p className="text-sm text-bold">Enable Compression</p>
+                    </div>
+                    <Switch
+                      isSelected={compression}
+                      onValueChange={setCompression}
+                      size="sm"
+                      isDisabled={true}
+                    />
+                  </div>
+                </div>
+
+                <Divider />
+
+                {/* Backup Scope */}
+                <div className="flex flex-col gap-4">
+                  <h3 className="text-lg font-semibold flex items-center gap-2">
+                    <Database size={20} />
+                    Backup Scope
+                  </h3>
+
+                  <div className="flex items-center justify-between">
+                    <div className="flex gap-2">
+                      <Boxes size={20} />
+                      <p className="text-sm text-bold">Cluster Backup</p>
+                    </div>
+                    <Switch
+                      isSelected={isClusterBackup}
+                      onValueChange={setIsClusterBackup}
+                      size="sm"
+                    />
+                  </div>
+
+                  {!isClusterBackup && (
+                    <>
+                      <Select
+                        label="Database"
+                        placeholder="Select database"
+                        selectedKeys={database ? [database] : []}
+                        onSelectionChange={(keys) => {
+                          const selectedKey = Array.from(keys)[0] as string;
+                          setDatabase(selectedKey);
+                          setCollection(""); // Reset collection when database changes
+                        }}
+                      >
+                        {(connection?.databases || []).map((db) => (
+                          <SelectItem key={db}>{db}</SelectItem>
+                        ))}
+                      </Select>
+
+                      <Select
+                        label="Collection (Optional)"
+                        placeholder="Select collection"
+                        selectedKeys={collection ? [collection] : []}
+                        onSelectionChange={(keys) => {
+                          const selectedKey = Array.from(keys)[0] as string;
+                          setCollection(selectedKey);
+                        }}
+                      >
+                        {(
+                          connection?.collections?.find(
+                            (coll) => coll.database === database
+                          )?.collections || []
+                        ).map((coll) => (
+                          <SelectItem key={coll}>{coll}</SelectItem>
+                        ))}
+                      </Select>
+                    </>
+                  )}
+                </div>
+              </ModalBody>
+              <ModalFooter>
+                <Button color="danger" variant="flat" onPress={onClose}>
+                  Cancel
+                </Button>
+                <Button
+                  onPress={handleSubmit}
+                  className="bg-primary-50"
+                  isLoading={isCreating || isUpdating}
+                >
+                  {editPolicy ? "Update Policy" : "Create Policy"}
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+// Delete Backup Policy Modal
+export function DeleteBackupPolicyModal({ policy }: { policy: TBackupPolicy }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { connection } = useConnectionStore();
+  const { deleteBackupPolicy, isDeleting } = useBackupStore();
+
+  const handleDelete = async () => {
+    const success = await deleteBackupPolicy(
+      connection?.connectionID as string,
+      policy.backupPolicyID
+    );
+    if (success) {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <Tooltip color="danger" content="Delete Policy">
+        <span
+          className="text-lg cursor-pointer text-danger active:opacity-50 hover:text-danger"
+          onClick={onOpen}
+        >
+          <Trash size={20} />
+        </span>
+      </Tooltip>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalContent>
+          <ModalHeader>Delete Backup Policy</ModalHeader>
+          <ModalBody>
+            <p>
+              Are you sure you want to delete the backup policy "{policy.name}"?
+            </p>
+            <p className="text-md text-red-500">
+              This will stop all scheduled backups for this policy.
+            </p>
+            <p className="text-sm text-yellow-500">
+              This action cannot be undone.
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button color="danger" variant="flat" onPress={onClose}>
+              Cancel
+            </Button>
+            <Button
+              onPress={handleDelete}
+              color="danger"
+              isLoading={isDeleting}
+            >
+              Delete Policy
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+// Trigger Backup Modal
+export function TriggerBackupModal({ policy }: { policy: TBackupPolicy }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { connection } = useConnectionStore();
+  const { triggerBackup, isTriggeringBackup } = useBackupStore();
+
+  const handleTrigger = async () => {
+    const success = await triggerBackup(
+      connection?.connectionID as string,
+      policy.backupPolicyID
+    );
+    if (success) {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <Tooltip content="Trigger Backup">
+        <span
+          className="text-lg cursor-pointer text-success active:opacity-50"
+          onClick={onOpen}
+        >
+          <Play size={20} />
+        </span>
+      </Tooltip>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalContent>
+          <ModalHeader className="flex items-center gap-2">
+            <Zap size={20} />
+            Trigger Backup
+          </ModalHeader>
+          <ModalBody>
+            <p>
+              Are you sure you want to manually trigger a backup for "
+              {policy.name}"?
+            </p>
+            <p className="text-sm text-default-500">
+              This will start a backup process immediately, regardless of the
+              scheduled interval.
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button color="danger" variant="flat" onPress={onClose}>
+              Cancel
+            </Button>
+            <Button
+              onPress={handleTrigger}
+              className="bg-success-50"
+              color="success"
+              isLoading={isTriggeringBackup}
+            >
+              Trigger Backup
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+// Main Backup Policies Component
+export default function ConnectionBackupPolicies() {
+  const { getBackupPolicies, backupPolicies, enablePolling, isLoading } =
+    useBackupStore();
+  const { id } = useParams();
+
+  const columns = [
+    { key: "name", label: "Policy Name" },
+    { key: "schedule", label: "Schedule" },
+    { key: "scope", label: "Scope" },
+    { key: "retention", label: "Retention" },
+    { key: "nextRun", label: "Next Run" },
+    { key: "status", label: "Status" },
+    { key: "actions", label: "Actions" },
+  ];
+
+  const POLLING_INTERVAL = 30000; // 30 seconds
+
+  useEffect(() => {
+    if (id) {
+      getBackupPolicies(id);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (enablePolling && id) {
+      const interval = setInterval(() => {
+        getBackupPolicies(id);
+      }, POLLING_INTERVAL);
+      return () => clearInterval(interval);
+    }
+  }, [id, enablePolling]);
+
+  const statusColorMap: {
+    [key: string]: "success" | "danger" | "warning" | "default";
+  } = {
+    Active: "success",
+    Inactive: "danger",
+  };
+
+  const renderCell = React.useCallback(
+    (
+      item: TBackupPolicy,
+      columnKey:
+        | keyof TBackupPolicy
+        | "actions"
+        | "schedule"
+        | "scope"
+        | "retention"
+        | "nextRun"
+    ) => {
+      if (columnKey === "actions") {
+        return (
+          <div className="flex gap-3">
+            <TriggerBackupModal policy={item} />
+            <CreateBackupPolicyModal editPolicy={item} />
+            <DeleteBackupPolicyModal policy={item} />
+          </div>
+        );
+      }
+
+      switch (columnKey) {
+        case "name":
+          return (
+            <div className="flex flex-col">
+              <p className="text-sm font-semibold">{item.name}</p>
+              <p className="text-xs text-default-500">
+                ID: {item.backupPolicyID}
+              </p>
+            </div>
+          );
+
+        case "schedule":
+          return (
+            <div className="flex items-center gap-2">
+              <Clock size={16} />
+              <span className="text-sm">
+                Every {item.interval} {item.timeUnit}
+              </span>
+            </div>
+          );
+
+        case "scope":
+          return (
+            <div className="flex flex-col gap-1">
+              <Chip
+                size="sm"
+                variant="flat"
+                startContent={<Database size={12} />}
+              >
+                {item.isClusterBackup ? "Cluster" : item.database}
+              </Chip>
+              {item.collection && (
+                <Chip size="sm" variant="flat" color="success">
+                  {item.collection}
+                </Chip>
+              )}
+            </div>
+          );
+
+        case "retention":
+          return (
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-1">
+                <Calendar size={14} />
+                <span className="text-sm">{item.retention} days</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <HardDrive size={14} />
+                <span className="text-sm">{item.keep} backups</span>
+              </div>
+            </div>
+          );
+
+        case "nextRun":
+          if (item.nextRun && item.nextRun > 0) {
+            const nextRunDate = new Date(item.nextRun);
+            const now = new Date();
+            const timeDiff = nextRunDate.getTime() - now.getTime();
+            const isOverdue = timeDiff < 0;
+
+            return (
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-1">
+                  <Calendar size={14} />
+                  <p className="text-sm">
+                    {new Date(item.nextRun).toDateString()}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Clock size={14} />
+                  <p className="text-xs text-default-500">
+                    {new Date(item.nextRun).toLocaleTimeString()}
+                  </p>
+                </div>
+                {isOverdue ? (
+                  <Chip size="sm" variant="flat" color="danger">
+                    Overdue
+                  </Chip>
+                ) : (
+                  <Chip size="sm" variant="flat" color="success">
+                    Scheduled
+                  </Chip>
+                )}
+              </div>
+            );
+          }
+          return (
+            <Chip size="sm" variant="flat" color="default">
+              Not scheduled
+            </Chip>
+          );
+
+        case "status":
+          return (
+            <Chip
+              className="capitalize"
+              color={statusColorMap[item.status]}
+              size="sm"
+              variant="flat"
+            >
+              {item.status}
+            </Chip>
+          );
+
+        default:
+          return item[columnKey as keyof TBackupPolicy]?.toString() || "";
+      }
+    },
+    []
+  );
+
+  const [page, setPage] = React.useState(1);
+  const rowsPerPage = 8;
+  const pages = Math.ceil((backupPolicies?.length || 0) / rowsPerPage);
+
+  const items = React.useMemo(() => {
+    const start = (page - 1) * rowsPerPage;
+    const end = start + rowsPerPage;
+    return backupPolicies?.slice(start, end) || [];
+  }, [page, rowsPerPage, backupPolicies]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-96">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex justify-between w-full items-center">
+        <div className="flex items-center justify-center">
+          {enablePolling && (
+            <Chip
+              color="success"
+              size="md"
+              variant="light"
+              startContent={<Spinner variant="spinner" size="sm" />}
+            >
+              Monitoring Active Policies
+            </Chip>
+          )}
+        </div>
+        <CreateBackupPolicyModal />
+      </div>
+      <Spacer y={4} />
+
+      {backupPolicies && backupPolicies.length > 0 ? (
+        <Table
+          aria-label="Backup policies table"
+          bottomContent={
+            pages > 1 ? (
+              <div className="flex justify-center w-full">
+                <Pagination
+                  isCompact
+                  showControls
+                  showShadow
+                  color="default"
+                  page={page}
+                  total={pages}
+                  onChange={(page) => setPage(page)}
+                />
+              </div>
+            ) : null
+          }
+        >
+          <TableHeader columns={columns}>
+            {(column) => (
+              <TableColumn key={column.key}>{column.label}</TableColumn>
+            )}
+          </TableHeader>
+          <TableBody items={items}>
+            {(item) => (
+              <TableRow key={item.backupPolicyID}>
+                {(columnKey) => (
+                  <TableCell>
+                    {renderCell(item, columnKey as keyof TBackupPolicy)}
+                  </TableCell>
+                )}
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      ) : (
+        <div className="flex flex-col items-center justify-center h-80">
+          <EmptyState
+            Icon={
+              <DotLottieReact
+                src="https://lottie.host/281813e4-12ea-4257-a041-69fc069edafe/dQopTPxL06.lottie"
+                loop
+                autoplay
+                backgroundColor="transparent"
+              />
+            }
+            Title="No backup policies found"
+            Description="Create your first backup policy to get started"
+            TitleClassName="-translate-y-20"
+            DescriptionClassName="-translate-y-20"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/connections/tabs/backups.tsx
+++ b/web/src/pages/connections/tabs/backups.tsx
@@ -1,16 +1,601 @@
-import EmptyState from "../../../components/emptyState";
-import LazyCat from "../../../icons/lazyCat";
+import {
+  Button,
+  Chip,
+  Divider,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Pagination,
+  Select,
+  SelectItem,
+  Spacer,
+  Spinner,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  useDisclosure,
+} from "@heroui/react";
+import { DotLottieReact } from "@lottiefiles/dotlottie-react";
+import React, { useEffect, useState } from "react";
+import { TBackup, TBackupWithPolicyName } from "../../../api/backup";
 
-export default function ConnectionBackups() {
+import {
+  Calendar,
+  Clock,
+  Database,
+  DatabaseBackup,
+  HardDrive,
+  Hammer,
+  Pencil,
+  Terminal,
+  Timer,
+  Trash,
+} from "lucide-react";
+import { useParams } from "react-router-dom";
+import { toast } from "sonner";
+import EmptyState from "../../../components/emptyState";
+import { useConnectionStore } from "../../../stores/connection.store";
+import { useBackupStore } from "../../../stores/backup.store";
+import RestoreAPI from "../../../api/restore";
+
+// Component for live duration display during processing
+function LiveDuration({ startTimestamp }: { startTimestamp: number }) {
+  const [liveDuration, setLiveDuration] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const currentTime = Date.now();
+      const duration = currentTime - startTimestamp;
+      setLiveDuration(duration);
+    }, 1000); // Update every second
+
+    return () => clearInterval(interval);
+  }, [startTimestamp]);
+
+  const formatDuration = (duration: number) => {
+    if (duration > 60000) {
+      return (duration / 60000).toFixed(1) + "m";
+    }
+    return (duration / 1000).toFixed(0) + "s";
+  };
+
   return (
-    <div>
-      <div className="flex flex-col items-center justify-center h-96">
-        <EmptyState
-          Icon={<LazyCat />}
-          Title="Good things take time"
-          Description="But i'm lazy, so it might take a while."
-        />
+    <p className="text-sm text-bold text-warning">
+      {formatDuration(liveDuration)}
+    </p>
+  );
+}
+
+// Restore Backup Modal
+export function RestoreBackup({ backup }: { backup: TBackup }) {
+  const { isOpen, onOpen, onOpenChange, onClose } = useDisclosure();
+  const { connection, connectionList } = useConnectionStore();
+  const [isLoading, setIsLoading] = useState(false);
+  const [allowUpdate, setAllowUpdate] = useState(false);
+  const [selectConnection, setSelectConnection] = useState<string | null>(null);
+  const [database, setDatabase] = useState("");
+
+  const handleRestore = async () => {
+    setIsLoading(true);
+    const { error } = await RestoreAPI.RestoreBackup({
+      connectionID: selectConnection ?? (connection?.connectionID as string),
+      backupID: backup.backupID,
+      update: allowUpdate,
+      database,
+    });
+    if (error) {
+      toast.error("Error Restoring Backup");
+      setIsLoading(false);
+      return;
+    }
+    toast.success("Backup Restored");
+    setIsLoading(false);
+    onClose();
+  };
+
+  return (
+    <>
+      <span className="cursor-pointer active:opacity-50" onClick={onOpen}>
+        <Tooltip content="Restore">
+          <DatabaseBackup size={20} className="text-primary" />
+        </Tooltip>
+      </span>
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        size="xl"
+        scrollBehavior="inside"
+      >
+        <ModalContent>
+          <ModalHeader className="flex gap-2">
+            <DatabaseBackup size={20} />
+            <p className="text-sm text-bold">Restore Backup</p>
+          </ModalHeader>
+          <ModalBody className="flex flex-col gap-2">
+            {!isLoading && (
+              <div className="gap-4 flex flex-col">
+                <p className="text-bold text-lg">
+                  Are you sure you want to restore this backup?
+                </p>
+                <div className="flex items-center justify-between ">
+                  <div className="flex flex-col gap-2">
+                    <div className="flex gap-2 items-center">
+                      <Pencil size={18} />
+                      <p className="text-md text-bold">Update Documents</p>
+                    </div>
+                    <p className="text-sm text-default-400">
+                      Update existing documents with the data from the backup
+                    </p>
+                  </div>
+                  <Switch
+                    isSelected={allowUpdate}
+                    onValueChange={setAllowUpdate}
+                    size="sm"
+                  ></Switch>
+                </div>
+                <Divider className="mt-4" />
+                <div className="flex items-center justify-center text-primary gap-2">
+                  <Hammer size={20} />
+                  <h1 className="text-lg">Advanced Toolings</h1>
+                </div>
+                <div className="flex items-center justify-between ">
+                  <div className="flex flex-col gap-2">
+                    <div className="flex gap-2 items-center">
+                      <Database size={18} />
+                      <p className="text-md text-bold">Restore To Connection</p>
+                    </div>
+                    <p className="text-sm text-default-400">
+                      Restore backup to different cluster
+                    </p>
+                  </div>
+                </div>
+                <Select
+                  label="Select Connection"
+                  onChange={(e) => setSelectConnection(e.target.value)}
+                >
+                  {(connectionList || []).map((connection) => (
+                    <SelectItem key={connection.connectionID}>
+                      {connection.name}
+                    </SelectItem>
+                  ))}
+                </Select>
+                <Select
+                  label="Select DB"
+                  onChange={(e) => setDatabase(e.target.value)}
+                >
+                  {(
+                    connectionList.find(
+                      (connection) =>
+                        connection.connectionID === selectConnection
+                    )?.databases || []
+                  )?.map((db) => (
+                    <SelectItem key={db}>{db}</SelectItem>
+                  ))}
+                </Select>
+              </div>
+            )}
+
+            {isLoading && (
+              <div className="m-auto flex items-center flex-col gap-2">
+                <div className="animate-levitate">
+                  <DotLottieReact
+                    src="https://lottie.host/8f027789-05c4-4553-a9c4-60cc13bdfdce/jCxtRmqwcd.lottie"
+                    loop
+                    autoplay
+                    backgroundColor="transparent"
+                    style={{ width: "300px", height: "150px" }}
+                  />
+                </div>
+                <div className="flex flex-col items-center">
+                  <p className=" text-lg">Grab a cup of coffee</p>
+                  <p className="text-sm animate-pulse">Restoring backup....</p>
+                </div>
+              </div>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              color="danger"
+              variant="flat"
+              onPress={() => {
+                onClose();
+              }}
+            >
+              Close
+            </Button>
+            <Button
+              onPress={() => {
+                handleRestore();
+              }}
+              className="bg-primary-50"
+              isLoading={isLoading}
+            >
+              Restore
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+// Render Backup Logs Modal
+export function RenderBackupLogs({ backup }: { backup: TBackup }) {
+  const { isOpen, onOpen, onOpenChange, onClose } = useDisclosure();
+
+  return (
+    <>
+      <Tooltip content="View Logs">
+        <span
+          className="text-lg cursor-pointer active:opacity-50"
+          onClick={onOpen}
+        >
+          <Terminal size={20} />
+        </span>
+      </Tooltip>
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        size="5xl"
+        scrollBehavior="inside"
+      >
+        <ModalContent>
+          <ModalHeader className="flex gap-2">
+            <Terminal size={20} />
+            <div className="flex flex-col">
+              <p className="text-sm text-bold">Backup Logs</p>
+              <p className="text-xs text-default-500">
+                Backup ID: {backup.backupID.split("_")[1]}
+              </p>
+            </div>
+          </ModalHeader>
+          <ModalBody className="flex flex-col gap-4">
+            <div className="flex gap-4 mb-4">
+              <Chip
+                size="sm"
+                variant="flat"
+                color={
+                  backup.status === "Success"
+                    ? "success"
+                    : backup.status === "Failed"
+                    ? "danger"
+                    : "warning"
+                }
+              >
+                {backup.status}
+              </Chip>
+              <Chip size="sm" variant="flat">
+                Duration:{" "}
+                {backup.duration > 60000
+                  ? (backup.duration / 60000).toFixed(2) + "m"
+                  : (backup.duration / 1000).toFixed(2) + "s"}
+              </Chip>
+              <Chip size="sm" variant="flat">
+                Size:{" "}
+                {backup.size / 1024 > 1024
+                  ? (backup.size / 1024 / 1024).toFixed(2) + " MB"
+                  : (backup.size / 1024).toFixed(2) + " KB"}
+              </Chip>
+            </div>
+            <pre className="whitespace-pre-wrap break-words text-small bg-default-100 p-4 rounded-lg">
+              {backup.logs || "No logs available for this backup."}
+            </pre>
+          </ModalBody>
+          <ModalFooter>
+            <Button color="danger" variant="flat" onPress={onClose}>
+              Close
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+// Main Backup Logs Component
+export default function ConnectionBackups() {
+  const { getBackupsForConnection, backups, enablePolling, isLoading } =
+    useBackupStore();
+  const { connection } = useConnectionStore();
+  const { id } = useParams();
+
+  const columns = [
+    { key: "backupID", label: "Backup ID" },
+    { key: "policy", label: "Policy" },
+    { key: "timestamp", label: "Timestamp" },
+    { key: "status", label: "Status" },
+    { key: "duration", label: "Duration" },
+    { key: "size", label: "Size" },
+    { key: "deletion", label: "Deletion" },
+    { key: "actions", label: "Actions" },
+  ];
+
+  const POLLING_INTERVAL = 10000; // 10 seconds
+
+  useEffect(() => {
+    if (id) {
+      getBackupsForConnection(id);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (enablePolling && id) {
+      const interval = setInterval(() => {
+        getBackupsForConnection(id);
+      }, POLLING_INTERVAL);
+      return () => clearInterval(interval);
+    }
+  }, [id, enablePolling]);
+
+  const statusColorMap: {
+    [key: string]: "success" | "danger" | "warning" | "default";
+  } = {
+    Success: "success",
+    Failed: "danger",
+    Processing: "warning",
+    Queued: "default",
+  };
+
+  const renderCell = React.useCallback(
+    (
+      item: TBackupWithPolicyName,
+      columnKey: keyof TBackup | "actions" | "policy" | "deletion"
+    ) => {
+      if (columnKey === "actions") {
+        return (
+          <div className="flex gap-3">
+            <RestoreBackup backup={item} />
+            <RenderBackupLogs backup={item} />
+          </div>
+        );
+      }
+
+      switch (columnKey) {
+        case "backupID":
+          return (
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-semibold">
+                {item.backupID.split("_")[1]}
+              </p>
+            </div>
+          );
+
+        case "policy":
+          return (
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-medium">
+                {item.policyName || "Unknown Policy"}
+              </p>
+              <p className="text-xs text-default-500">
+                ID: {item.backupPolicyID}
+              </p>
+            </div>
+          );
+
+        case "timestamp":
+          return (
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-1">
+                <Calendar size={14} />
+                <p className="text-sm">
+                  {new Date(item.timestamp).toDateString()}
+                </p>
+              </div>
+              <div className="flex items-center gap-1">
+                <Clock size={14} />
+                <p className="text-xs text-default-500">
+                  {new Date(item.timestamp).toLocaleTimeString()}
+                </p>
+              </div>
+            </div>
+          );
+
+        case "duration":
+          // Show live duration for processing backups
+          if (item.status === "Processing") {
+            return <LiveDuration startTimestamp={item.timestamp} />;
+          }
+          // Show static duration for completed backups
+          return (
+            <div className="flex items-center gap-1">
+              <Timer size={14} />
+              <p className="text-sm">
+                {item.duration > 60000
+                  ? (item.duration / 60000).toFixed(2) + "m"
+                  : (item.duration / 1000).toFixed(2) + "s"}
+              </p>
+            </div>
+          );
+
+        case "size":
+          return (
+            <div className="flex items-center gap-1">
+              <HardDrive size={14} />
+              <p className="text-sm">
+                {item.size / 1024 > 1024
+                  ? (item.size / 1024 / 1024).toFixed(2) + " MB"
+                  : (item.size / 1024).toFixed(2) + " KB"}
+              </p>
+            </div>
+          );
+
+        case "deletion":
+          if (item.toBeDeletedAt && item.toBeDeletedAt > 0) {
+            const now = Date.now();
+            const deletionTime = item.toBeDeletedAt;
+            const timeRemaining = deletionTime - now;
+
+            if (timeRemaining > 0) {
+              const days = Math.floor(timeRemaining / (1000 * 60 * 60 * 24));
+              const hours = Math.floor(
+                (timeRemaining % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+              );
+              const minutes = Math.floor(
+                (timeRemaining % (1000 * 60 * 60)) / (1000 * 60)
+              );
+
+              return (
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-1">
+                    <Trash size={14} />
+                    <p className="text-sm">
+                      {new Date(deletionTime).toDateString()}
+                    </p>
+                  </div>
+                  <Chip size="sm" variant="flat" color="warning">
+                    {days > 0 ? `${days}d ${hours}h` : `${hours}h ${minutes}m`}{" "}
+                    left
+                  </Chip>
+                </div>
+              );
+            } else {
+              return (
+                <Chip size="sm" variant="flat" color="danger">
+                  Expired
+                </Chip>
+              );
+            }
+          }
+          return (
+            <Chip size="sm" variant="flat" color="success">
+              Permanent
+            </Chip>
+          );
+
+        case "status":
+          return (
+            <Chip
+              className="capitalize"
+              color={statusColorMap[item.status]}
+              size="sm"
+              variant="flat"
+              startContent={
+                item.status === "Processing" ? (
+                  <Spinner
+                    className="w-3 h-3"
+                    variant="simple"
+                    color={statusColorMap[item.status]}
+                  />
+                ) : null
+              }
+            >
+              {item.status}
+            </Chip>
+          );
+
+        default:
+          return item[columnKey as keyof TBackup]?.toString() || "";
+      }
+    },
+    []
+  );
+
+  const [page, setPage] = React.useState(1);
+  const rowsPerPage = 10;
+  const pages = Math.ceil((backups?.length || 0) / rowsPerPage);
+
+  const items = React.useMemo(() => {
+    const start = (page - 1) * rowsPerPage;
+    const end = start + rowsPerPage;
+    return backups?.slice(start, end) || [];
+  }, [page, rowsPerPage, backups]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-96">
+        <Spinner size="lg" />
       </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex justify-between w-full items-center">
+        <div className="flex items-center justify-center">
+          {enablePolling && (
+            <Chip
+              color="success"
+              size="md"
+              variant="light"
+              startContent={<Spinner variant="spinner" size="sm" />}
+            >
+              Monitoring Active Backups
+            </Chip>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Database size={16} />
+          <span className="text-sm text-default-600">
+            {connection?.name} Backup History
+          </span>
+        </div>
+      </div>
+      <Spacer y={4} />
+
+      {backups && backups.length > 0 ? (
+        <Table
+          aria-label="Backup logs table"
+          bottomContent={
+            pages > 1 ? (
+              <div className="flex justify-center w-full">
+                <Pagination
+                  isCompact
+                  showControls
+                  showShadow
+                  color="default"
+                  page={page}
+                  total={pages}
+                  onChange={(page) => setPage(page)}
+                />
+              </div>
+            ) : null
+          }
+        >
+          <TableHeader columns={columns}>
+            {(column) => (
+              <TableColumn key={column.key}>{column.label}</TableColumn>
+            )}
+          </TableHeader>
+          <TableBody items={items}>
+            {(item) => (
+              <TableRow key={item.backupID}>
+                {(columnKey) => (
+                  <TableCell>
+                    {renderCell(
+                      item as unknown as TBackupWithPolicyName,
+                      columnKey as keyof (TBackupWithPolicyName | TBackup)
+                    )}
+                  </TableCell>
+                )}
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      ) : (
+        <div className="flex flex-col items-center justify-center h-80">
+          <EmptyState
+            Icon={
+              <DotLottieReact
+                src="https://lottie.host/281813e4-12ea-4257-a041-69fc069edafe/dQopTPxL06.lottie"
+                loop
+                autoplay
+                backgroundColor="transparent"
+              />
+            }
+            Title="No backup logs found"
+            Description="Backup logs will appear here once backup policies are executed"
+            TitleClassName="-translate-y-20"
+            DescriptionClassName="-translate-y-20"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/connections/tabs/overiew.tsx
+++ b/web/src/pages/connections/tabs/overiew.tsx
@@ -6,10 +6,23 @@ import {
   Chip,
   Listbox,
   ListboxItem,
+  Badge,
+  Divider,
 } from "@heroui/react";
 import { useConnectionStore } from "../../../stores/connection.store";
 import ConnectionAPI from "../../../api/connection";
 import { toast } from "sonner";
+import {
+  Database,
+  Server,
+  RefreshCw,
+  Activity,
+  Shield,
+  Clock,
+  HardDrive,
+  Globe,
+  Info,
+} from "lucide-react";
 
 export type Props = {
   ConnectionID: string;
@@ -17,90 +30,249 @@ export type Props = {
 export default function ConnectionOverview() {
   const { connection, getConnection } = useConnectionStore();
 
+  const handleSyncConnection = async () => {
+    if (!connection) return;
+
+    const { error } = await ConnectionAPI.SyncConnectionRequest(
+      connection.connectionID
+    );
+    if (error) {
+      toast.error(error.error);
+      return;
+    }
+    toast.success("Connection synced successfully");
+    getConnection(connection.connectionID);
+  };
+
+  const getConnectionStatus = () => {
+    // Mock status - in real app, this would come from health check
+    return {
+      status: "connected",
+      lastSync: "-",
+      latency: "-",
+    };
+  };
+
+  const status = getConnectionStatus();
+
   return (
-    <>
+    <div className="space-y-6">
       {connection && (
         <>
-          <div className="flex  items-center justify-between w-full p-2 px-4 mb-2 border-1 rounded-lg border-white/20">
-            <p className="text-md text-slate-300">
-              Re Sync Connection Databases
-            </p>
-            <Button
-              size="sm"
-              onPress={async () => {
-                const { error } = await ConnectionAPI.SyncConnectionRequest(
-                  connection.connectionID
-                );
-                if (error) {
-                  toast.error(error.error);
-                }
-                toast.success("Connection Synced");
-                getConnection(connection.connectionID);
-              }}
-            >
-              Re Sync
-            </Button>
+          {/* Header Section */}
+          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 p-6 bg-gradient-to-r from-primary-50/10 to-secondary-50/20 border border-primary-200/30 rounded-xl backdrop-blur-sm">
+            <div className="flex items-center gap-4">
+              <div className="p-3 bg-primary-100/50 rounded-lg">
+                <Database className="w-6 h-6 text-primary-600" />
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold text-foreground">
+                  {connection.name}
+                </h2>
+                <p className="text-sm text-default-500 flex items-center gap-2">
+                  <Globe className="w-4 h-4" />
+                  {connection.host}:{connection.port}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Badge
+                color={status.status === "connected" ? "success" : "danger"}
+                variant="flat"
+                className="text-xs"
+              >
+                {status.status === "connected" ? "Online" : "Offline"}
+              </Badge>
+              <Button
+                size="sm"
+                color="default"
+                variant="flat"
+                startContent={<RefreshCw className="w-4 h-4" />}
+                onPress={handleSyncConnection}
+                className="font-medium"
+              >
+                Sync Connection
+              </Button>
+            </div>
           </div>
-          <div className="flex gap-4">
-            <Card
-              isBlurred
-              className="w-8/12 border-1 border-slate-500 bg-background/100 dark:bg-default-100/50"
-              shadow="sm"
-            >
-              <CardHeader className="flex gap-3">
-                <p className="text-md text-slate-300">Connection Details</p>
+
+          {/* Stats Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <Card className="border border-default-200/50 bg-background/50 backdrop-blur-sm">
+              <CardBody className="flex flex-row items-center gap-3 p-4">
+                <div className="p-2 bg-success-100/50 rounded-lg">
+                  <Database className="w-5 h-5 text-success-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-default-500">Databases</p>
+                  <p className="text-lg font-semibold text-foreground">
+                    {connection.databases.length}
+                  </p>
+                </div>
+              </CardBody>
+            </Card>
+
+            <Card className="border border-default-200/50 bg-background/50 backdrop-blur-sm">
+              <CardBody className="flex flex-row items-center gap-3 p-4">
+                <div className="p-2 bg-warning-100/50 rounded-lg">
+                  <Activity className="w-5 h-5 text-warning-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-default-500">Latency</p>
+                  <p className="text-lg font-semibold text-foreground">
+                    {status.latency}
+                  </p>
+                </div>
+              </CardBody>
+            </Card>
+
+            <Card className="border border-default-200/50 bg-background/50 backdrop-blur-sm">
+              <CardBody className="flex flex-row items-center gap-3 p-4">
+                <div className="p-2 bg-info-100/50 rounded-lg">
+                  <Shield className="w-5 h-5 text-info-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-default-500">Security</p>
+                  <p className="text-lg font-semibold text-foreground">
+                    {connection.scheme.toUpperCase()}
+                  </p>
+                </div>
+              </CardBody>
+            </Card>
+
+            <Card className="border border-default-200/50 bg-background/50 backdrop-blur-sm">
+              <CardBody className="flex flex-row items-center gap-3 p-4">
+                <div className="p-2 bg-secondary-100/50 rounded-lg">
+                  <Clock className="w-5 h-5 text-secondary-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-default-500">Last Sync</p>
+                  <p className="text-lg font-semibold text-foreground">
+                    {status.lastSync}
+                  </p>
+                </div>
+              </CardBody>
+            </Card>
+          </div>
+
+          {/* Main Content Grid */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {/* Connection Details */}
+            <Card className="lg:col-span-2 border border-default-200/50 bg-background/50 backdrop-blur-sm">
+              <CardHeader className="flex items-center gap-3 pb-3">
+                <Server className="w-5 h-5 text-primary-600" />
+                <h3 className="text-lg font-semibold text-foreground">
+                  Connection Details
+                </h3>
               </CardHeader>
-              <CardBody>
-                <div className="flex flex-col gap-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm text-default-500">ConnectionID</p>
-                    <p className="text-sm text-slate-300">
-                      <Chip className="bg-primary-50">
+              <Divider />
+              <CardBody className="pt-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-default-500 flex items-center gap-2">
+                        <Info className="w-4 h-4" />
+                        Connection ID
+                      </span>
+                      <Chip
+                        size="sm"
+                        variant="flat"
+                        color="primary"
+                        className="font-mono text-xs"
+                      >
                         {connection.connectionID}
                       </Chip>
-                    </p>
-                  </div>
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm text-default-500">Name</p>
-                    <p className="text-sm text-slate-300">{connection.name}</p>
-                  </div>
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm text-default-500">Cluster Name</p>
-                    <p className="text-sm text-slate-300">
-                      {connection.host.split(".")[0]}
-                    </p>
-                  </div>
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm text-default-500">Host</p>
-                    <p className="text-sm text-slate-300">{connection.host}</p>
+                    </div>
+
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-default-500">Name</span>
+                      <span className="text-sm font-medium text-foreground">
+                        {connection.name}
+                      </span>
+                    </div>
+
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-default-500">Cluster</span>
+                      <span className="text-sm font-medium text-foreground">
+                        {connection.host.split(".")[0]}
+                      </span>
+                    </div>
                   </div>
 
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm text-default-500">Port</p>
-                    <p className="text-sm text-slate-300">{connection.port}</p>
-                  </div>
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm text-default-500">Scheme</p>
-                    <p className="text-sm text-slate-300">
-                      {connection.scheme}
-                    </p>
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-default-500">Host</span>
+                      <span className="text-sm font-medium text-foreground font-mono">
+                        {connection.host}
+                      </span>
+                    </div>
+
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-default-500">Port</span>
+                      <span className="text-sm font-medium text-foreground">
+                        {connection.port}
+                      </span>
+                    </div>
+
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-default-500">Protocol</span>
+                      <Chip
+                        size="sm"
+                        variant="flat"
+                        color={
+                          connection.scheme === "mongodb+srv"
+                            ? "success"
+                            : "default"
+                        }
+                        className="text-xs"
+                      >
+                        {connection.scheme}
+                      </Chip>
+                    </div>
                   </div>
                 </div>
               </CardBody>
             </Card>
-            <Card
-              isBlurred
-              className="w-4/12 border-1 border-slate-500 bg-background/100 dark:bg-default-100/50 max-h-[300px] overflow-y-auto"
-              shadow="sm"
-            >
-              <CardHeader>
-                <p className="text-md text-slate-300">Databases</p>
+
+            {/* Databases List */}
+            <Card className="border border-default-200/50 bg-background/50 backdrop-blur-sm">
+              <CardHeader className="flex items-center gap-3 pb-3">
+                <HardDrive className="w-5 h-5 text-primary-600" />
+                <h3 className="text-lg font-semibold text-foreground">
+                  Databases
+                </h3>
+                <Badge color="primary" variant="flat" size="sm">
+                  {connection.databases.length}
+                </Badge>
               </CardHeader>
-              <CardBody>
-                <Listbox className="w-full">
+              <Divider />
+              <CardBody className="pt-4">
+                <Listbox
+                  className="w-full"
+                  aria-label="Database list"
+                  variant="flat"
+                >
                   {connection.databases.map((db, index) => (
-                    <ListboxItem key={index}>
-                      {db.toLocaleUpperCase()}
+                    <ListboxItem
+                      key={index}
+                      className="rounded-lg mb-1 hover:bg-default-100"
+                      startContent={
+                        <div className="p-1 bg-primary-100/50 rounded">
+                          <Database className="w-4 h-4 text-primary-600" />
+                        </div>
+                      }
+                    >
+                      <div className="flex flex-col">
+                        <span className="font-medium text-foreground">
+                          {db.toUpperCase()}
+                        </span>
+                        <span className="text-xs text-default-500">
+                          {connection.collections.find((c) => c.database === db)
+                            ?.collections.length || 0}{" "}
+                          collections
+                        </span>
+                      </div>
                     </ListboxItem>
                   ))}
                 </Listbox>
@@ -109,6 +281,6 @@ export default function ConnectionOverview() {
           </div>
         </>
       )}
-    </>
+    </div>
   );
 }

--- a/web/src/pages/connections/tabs/restores.tsx
+++ b/web/src/pages/connections/tabs/restores.tsx
@@ -17,9 +17,9 @@ import {
   TableHeader,
   TableRow,
   Tooltip,
-  useDisclosure
+  useDisclosure,
 } from "@heroui/react";
-import { Terminal } from "lucide-react";
+import { Calendar, Clock, Terminal, Timer } from "lucide-react";
 import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { TRestore } from "../../../api/restore";
@@ -27,13 +27,10 @@ import EmptyState from "../../../components/emptyState";
 import { useConnectionStore } from "../../../stores/connection.store";
 import { useRestoreStore } from "../../../stores/restore.store";
 
-
-
-
 export function RenderLogs({ restore_id }: { restore_id: string }) {
   const { isOpen, onOpen, onOpenChange, onClose } = useDisclosure();
 
- const { getRestore,restore,setRestore } = useRestoreStore();
+  const { getRestore, restore, setRestore } = useRestoreStore();
   const { connection } = useConnectionStore();
 
   useEffect(() => {
@@ -46,14 +43,19 @@ export function RenderLogs({ restore_id }: { restore_id: string }) {
   return (
     <>
       <Tooltip content="View Logs">
-      <span
-        className="text-lg cursor-pointer active:opacity-50"
-        onClick={onOpen}
-      >
-        <Terminal size={20} />
-      </span>
+        <span
+          className="text-lg cursor-pointer active:opacity-50"
+          onClick={onOpen}
+        >
+          <Terminal size={20} />
+        </span>
       </Tooltip>
-      <Modal isOpen={isOpen} onOpenChange={onOpenChange} size="5xl" scrollBehavior="inside">
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        size="5xl"
+        scrollBehavior="inside"
+      >
         <ModalContent>
           <ModalHeader className="flex gap-2">
             <Terminal size={20} />
@@ -95,7 +97,7 @@ export default function ConnectionRestores() {
   }[] = [
     { key: "restoreID", label: "Restore ID" },
     { key: "type", label: "Type" },
-    {key: "restoreFrom", label: "Restore From"},
+    { key: "restoreFrom", label: "Restore From" },
     { key: "database", label: "Database" },
     { key: "timestamp", label: "Timestamp" },
     { key: "status", label: "Status" },
@@ -107,43 +109,57 @@ export default function ConnectionRestores() {
     getRestores(id as string);
   }, [id]);
 
-
-  const statusColorMap: { [key in TRestore["status"]]: string } = {
+  const statusColorMap: {
+    [key: string]: "success" | "danger" | "warning" | "default";
+  } = {
     Success: "success",
     Failed: "danger",
+    Processing: "warning",
+    Queued: "default",
   };
 
   const renderCell = React.useCallback(
-    (item: TRestore, columnKey: keyof TRestore | 'actions' | "restoreFrom") => {
-      if (columnKey === 'actions') {
+    (item: TRestore, columnKey: keyof TRestore | "actions" | "restoreFrom") => {
+      if (columnKey === "actions") {
         return (
           <div className="flex gap-3">
-              <RenderLogs restore_id={item.restoreID} />
+            <RenderLogs restore_id={item.restoreID} />
           </div>
         );
       }
-      
+
       const cellValue = item[columnKey as keyof TRestore]?.toString() || "";
 
       switch (columnKey) {
         case "timestamp":
           return (
-            <p className="text-sm capitalize text-bold">
-             {new Date(parseInt(cellValue)).toDateString() +
-                " " +
-                "(" + new Date(parseInt(cellValue)).toLocaleTimeString() + ")"
-                }
-            </p>
+            <div className="flex flex-col">
+              <div className="flex items-center gap-1">
+                <Calendar size={14} />
+                <p className="text-sm">
+                  {new Date(item.timestamp).toDateString()}
+                </p>
+              </div>
+              <div className="flex items-center gap-1">
+                <Clock size={14} />
+                <p className="text-xs text-default-500">
+                  {new Date(item.timestamp).toLocaleTimeString()}
+                </p>
+              </div>
+            </div>
           );
         case "duration":
           return (
-            <p className="text-sm text-bold">
-              {parseInt(cellValue) > 60000
-                ? parseInt(cellValue) / 60000 + "m"
-                : parseInt(cellValue) / 1000 + "s"}
-            </p>
+            <div className="flex items-center gap-1">
+              <Timer size={14} />
+              <p className="text-sm">
+                {item.duration > 60000
+                  ? (item.duration / 60000).toFixed(2) + "m"
+                  : (item.duration / 1000).toFixed(2) + "s"}
+              </p>
+            </div>
           );
-        
+
         case "restoreFrom":
           return (
             <Link size="sm" className="text-primary" showAnchorIcon>
@@ -154,20 +170,26 @@ export default function ConnectionRestores() {
         case "status":
           return (
             <Chip
-              className="capitalize"
-              color={statusColorMap[item.status] as "success" | "danger"}
-              size="sm"
+              className="capitalize gap-1 border-0"
+              color={statusColorMap[item.status]}
+              size="md"
               variant="dot"
             >
-              {cellValue}
+              {item.status}
             </Chip>
           );
 
         case "restoreID":
           return (
-            <Chip size="sm" variant="solid">
-              {cellValue}
-            </Chip>
+            <div className="flex flex-col">
+              <Chip
+                size="sm"
+                variant="light"
+                className="text-sm text-foreground-600"
+              >
+                {item.restoreID.split("_")[1]}
+              </Chip>
+            </div>
           );
 
         case "type":
@@ -180,8 +202,7 @@ export default function ConnectionRestores() {
               {cellValue?.length ? cellValue : "Cluster"}
             </Chip>
           );
-        
-        
+
         default:
           return cellValue;
       }
@@ -202,76 +223,73 @@ export default function ConnectionRestores() {
 
   return (
     <div className="w-full">
-     
       <Spacer y={4} />
-      {
-        restoreList?.length > 0 && (
-                <Table
-        aria-label="Restore Table"
-        bottomContent={
-          <div className="flex justify-center w-full">
-            <Pagination
-              isCompact
-              showControls
-              showShadow
-              color="default"
-              page={page}
-              total={pages}
-              onChange={(page) => setPage(page)}
-            />
-          </div>
-        }
-      >
-        <TableHeader columns={columns}>
-          {(column) => (
-            <TableColumn key={column.key}>{column.label}</TableColumn>
-          )}
-        </TableHeader>
-        <TableBody
-          items={
-            items.map((item) => ({
-              ...item,
-              actions: "",
-              type: item?.snapshotID !== "" ? "Snapshot" : "Backup",
-              restoreFrom: item?.snapshotID?.length
-                ? item?.snapshotID
-                : item?.backupID,
-            })) || []
-          }
-        >
-          {(item) => (
-            <TableRow key={item?.restoreID}>
-              {(columnKey) => (
-                <TableCell>
-                  {renderCell(item as TRestore, columnKey as keyof TRestore)}
-                </TableCell>
-              )}
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
-        )
-}
-      {
-        restoreList?.length === 0 && (
-          <div>
-            <div className="flex flex-col items-center justify-center h-80">
-              <EmptyState
-                Icon={ <DotLottieReact
-                src="https://lottie.host/281813e4-12ea-4257-a041-69fc069edafe/dQopTPxL06.lottie"
-                loop
-                autoplay
-                backgroundColor="transparent"
-              />}
-                Title="Nothing to see here....."
-                Description="Start a restore to see something here, meanwhile let me sleep."
-                TitleClassName="-translate-y-20"
-                DescriptionClassName="-translate-y-20"
+      {restoreList?.length > 0 && (
+        <Table
+          aria-label="Restore Table"
+          bottomContent={
+            <div className="flex justify-center w-full">
+              <Pagination
+                isCompact
+                showControls
+                showShadow
+                color="default"
+                page={page}
+                total={pages}
+                onChange={(page) => setPage(page)}
               />
             </div>
+          }
+        >
+          <TableHeader columns={columns}>
+            {(column) => (
+              <TableColumn key={column.key}>{column.label}</TableColumn>
+            )}
+          </TableHeader>
+          <TableBody
+            items={
+              items.map((item) => ({
+                ...item,
+                actions: "",
+                type: item?.snapshotID !== "" ? "Snapshot" : "Backup",
+                restoreFrom: item?.snapshotID?.length
+                  ? item?.snapshotID
+                  : item?.backupID,
+              })) || []
+            }
+          >
+            {(item) => (
+              <TableRow key={item?.restoreID}>
+                {(columnKey) => (
+                  <TableCell>
+                    {renderCell(item as TRestore, columnKey as keyof TRestore)}
+                  </TableCell>
+                )}
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      )}
+      {restoreList?.length === 0 && (
+        <div>
+          <div className="flex flex-col items-center justify-center h-80">
+            <EmptyState
+              Icon={
+                <DotLottieReact
+                  src="https://lottie.host/281813e4-12ea-4257-a041-69fc069edafe/dQopTPxL06.lottie"
+                  loop
+                  autoplay
+                  backgroundColor="transparent"
+                />
+              }
+              Title="Nothing to see here....."
+              Description="Start a restore to see something here, meanwhile let me sleep."
+              TitleClassName="-translate-y-20"
+              DescriptionClassName="-translate-y-20"
+            />
           </div>
-        )
-      }
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/connections/tabs/snapshots.tsx
+++ b/web/src/pages/connections/tabs/snapshots.tsx
@@ -33,13 +33,17 @@ import SnapShotAPI, { TSnapShot } from "../../../api/snapshot";
 import {
   Boxes,
   Cable,
+  Calendar,
   Camera,
+  Clock,
   Database,
   DatabaseBackup,
   Download,
   GitBranch,
   Hammer,
+  HardDrive,
   Pencil,
+  Timer,
   Shrink,
   Tags,
   Terminal,
@@ -618,30 +622,39 @@ export default function ConnectionSnapshots() {
       switch (columnKey) {
         case "timestamp":
           return (
-            <p className="text-sm capitalize text-bold">
-              {new Date(parseInt(cellValue)).toDateString() +
-                " " +
-                "(" +
-                new Date(parseInt(cellValue)).toLocaleTimeString() +
-                ")"}
-            </p>
+            <div className="flex flex-col">
+              <div className="flex items-center gap-1">
+                <Calendar size={14} />
+                <p className="text-sm">
+                  {new Date(item.timestamp).toDateString()}
+                </p>
+              </div>
+              <div className="flex items-center gap-1">
+                <Clock size={14} />
+                <p className="text-xs text-default-500">
+                  {new Date(item.timestamp).toLocaleTimeString()}
+                </p>
+              </div>
+            </div>
           );
         case "duration":
           return (
-            <p className="text-sm text-bold">
+            <div className="flex items-center gap-1">
+              <Timer size={14} />
               {parseInt(cellValue) > 60000
                 ? parseInt(cellValue) / 60000 + "m"
                 : parseInt(cellValue) / 1000 + "s"}
-            </p>
+            </div>
           );
 
         case "size":
           return (
             <span className="flex gap-1 items-center">
+              <HardDrive size={14} />
               <p className="text-sm text-bold">
                 {parseInt(cellValue) / 1024 > 1024
-                  ? (parseInt(cellValue) / 1024 / 1024).toFixed(2) + " mb"
-                  : (parseInt(cellValue) / 1024).toFixed(2) + " kb"}
+                  ? (parseInt(cellValue) / 1024 / 1024).toFixed(2) + " MB"
+                  : (parseInt(cellValue) / 1024).toFixed(2) + " KB"}
               </p>
               {item?.compression && <Chip size="sm">gzip</Chip>}
             </span>

--- a/web/src/stores/backup.store.ts
+++ b/web/src/stores/backup.store.ts
@@ -1,0 +1,264 @@
+import { create } from "zustand";
+import BackupAPI, {
+  TBackupPolicy,
+  TBackup,
+  TBackupWithPolicyName,
+} from "../api/backup";
+import { toast } from "sonner";
+
+type BackupStore = {
+  // Backup Policies
+  backupPolicy: TBackupPolicy | null;
+  backupPolicies: TBackupPolicy[];
+
+  // Backup Logs
+  backups: (TBackup | TBackupWithPolicyName)[];
+
+  // Loading states
+  isLoading: boolean;
+  isCreating: boolean;
+  isUpdating: boolean;
+  isDeleting: boolean;
+  isTriggeringBackup: boolean;
+
+  // Polling for active backups
+  enablePolling: boolean;
+
+  // Actions for Backup Policies
+  getBackupPolicy: (
+    connectionID: string,
+    backupPolicyID: string
+  ) => Promise<void>;
+  getBackupPolicies: (connectionID: string) => Promise<void>;
+  getAllBackupPolicies: () => Promise<void>;
+  createBackupPolicy: (
+    connectionID: string,
+    policy: Omit<TBackupPolicy, "backupPolicyID" | "connectionID" | "isDeleted">
+  ) => Promise<boolean>;
+  updateBackupPolicy: (
+    connectionID: string,
+    backupPolicyID: string,
+    policy: Partial<Omit<TBackupPolicy, "backupPolicyID" | "connectionID">>
+  ) => Promise<boolean>;
+  deleteBackupPolicy: (
+    connectionID: string,
+    backupPolicyID: string
+  ) => Promise<boolean>;
+  triggerBackup: (
+    connectionID: string,
+    backupPolicyID: string
+  ) => Promise<boolean>;
+
+  // Actions for Backup Logs
+  getBackupsForPolicy: (
+    connectionID: string,
+    backupPolicyID: string
+  ) => Promise<void>;
+  getBackupsForConnection: (connectionID: string) => Promise<void>;
+
+  // Utility actions
+  clearBackupPolicy: () => void;
+  setBackupPolicy: (policy: TBackupPolicy | null) => void;
+  findBackupPolicy: (backupPolicyID: string) => TBackupPolicy | undefined;
+};
+
+export const useBackupStore = create<BackupStore>((set, get) => ({
+  // Initial state
+  backupPolicy: null,
+  backupPolicies: [],
+  backups: [],
+  isLoading: false,
+  isCreating: false,
+  isUpdating: false,
+  isDeleting: false,
+  isTriggeringBackup: false,
+  enablePolling: false,
+
+  // Backup Policy Actions
+  getBackupPolicy: async (connectionID: string, backupPolicyID: string) => {
+    set({ isLoading: true });
+    const { backupPolicy, error } = await BackupAPI.GetBackupPolicyRequest(
+      connectionID,
+      backupPolicyID
+    );
+    if (error) {
+      toast.error(error.error);
+      set({ isLoading: false });
+      return;
+    }
+    set({ backupPolicy, isLoading: false });
+  },
+
+  getBackupPolicies: async (connectionID: string) => {
+    set({ isLoading: true });
+    const { backupPolicies, error } = await BackupAPI.GetBackupPoliciesRequest(
+      connectionID
+    );
+    if (error) {
+      toast.error(error.error);
+      set({ isLoading: false });
+      return;
+    }
+
+    // Check if any backup policies have active status for polling
+    const enablePolling = backupPolicies?.some(
+      (policy) => policy.status === "Active"
+    );
+
+    set({
+      backupPolicies: backupPolicies ?? [],
+      enablePolling,
+      isLoading: false,
+    });
+  },
+
+  getAllBackupPolicies: async () => {
+    set({ isLoading: true });
+    const { backupPolicies, error } =
+      await BackupAPI.GetAllBackupPoliciesRequest();
+    if (error) {
+      toast.error(error.error);
+      set({ isLoading: false });
+      return;
+    }
+    set({ backupPolicies: backupPolicies ?? [], isLoading: false });
+  },
+
+  createBackupPolicy: async (
+    connectionID: string,
+    policy: Omit<TBackupPolicy, "backupPolicyID" | "connectionID" | "isDeleted">
+  ) => {
+    set({ isCreating: true });
+    const { backupPolicy, error } = await BackupAPI.CreateBackupPolicyRequest(
+      connectionID,
+      policy
+    );
+    if (error) {
+      toast.error(error.error);
+      set({ isCreating: false });
+      return false;
+    }
+
+    toast.success("Backup policy created successfully");
+
+    // Refresh the backup policies list
+    get().getBackupPolicies(connectionID);
+    set({ isCreating: false });
+    return true;
+  },
+
+  updateBackupPolicy: async (
+    connectionID: string,
+    backupPolicyID: string,
+    policy: Partial<Omit<TBackupPolicy, "backupPolicyID" | "connectionID">>
+  ) => {
+    set({ isUpdating: true });
+    const { backupPolicy, error } = await BackupAPI.UpdateBackupPolicyRequest(
+      connectionID,
+      backupPolicyID,
+      policy
+    );
+    if (error) {
+      toast.error(error.error);
+      set({ isUpdating: false });
+      return false;
+    }
+
+    toast.success("Backup policy updated successfully");
+
+    // Refresh the backup policies list
+    get().getBackupPolicies(connectionID);
+    set({ isUpdating: false });
+    return true;
+  },
+
+  deleteBackupPolicy: async (connectionID: string, backupPolicyID: string) => {
+    set({ isDeleting: true });
+    const { error } = await BackupAPI.DeleteBackupPolicyRequest(
+      connectionID,
+      backupPolicyID
+    );
+    if (error) {
+      toast.error(error.error);
+      set({ isDeleting: false });
+      return false;
+    }
+
+    toast.success("Backup policy deleted successfully");
+
+    // Refresh the backup policies list
+    get().getBackupPolicies(connectionID);
+    set({ isDeleting: false });
+    return true;
+  },
+
+  triggerBackup: async (connectionID: string, backupPolicyID: string) => {
+    set({ isTriggeringBackup: true });
+    const { error } = await BackupAPI.TriggerBackupRequest(
+      connectionID,
+      backupPolicyID
+    );
+    if (error) {
+      toast.error(error.error);
+      set({ isTriggeringBackup: false });
+      return false;
+    }
+
+    toast.success("Backup triggered successfully");
+    set({ isTriggeringBackup: false });
+    return true;
+  },
+
+  // Backup Logs Actions
+  getBackupsForPolicy: async (connectionID: string, backupPolicyID: string) => {
+    set({ isLoading: true });
+    const { backups, error } = await BackupAPI.GetBackupsForPolicyRequest(
+      connectionID,
+      backupPolicyID
+    );
+    if (error) {
+      toast.error(error.error);
+      set({ isLoading: false });
+      return;
+    }
+
+    // Check if any backups are in processing state for polling
+    const enablePolling = backups?.some(
+      (backup) => backup.status === "Processing" || backup.status === "Queued"
+    );
+
+    set({ backups: backups ?? [], enablePolling, isLoading: false });
+  },
+
+  getBackupsForConnection: async (connectionID: string) => {
+    set({ isLoading: true });
+    const { backups, error } = await BackupAPI.GetBackupsForConnectionRequest(
+      connectionID
+    );
+    if (error) {
+      toast.error(error.error);
+      set({ isLoading: false });
+      return;
+    }
+
+    // Check if any backups are in processing state for polling
+    const enablePolling = backups?.some(
+      (backup) => backup.status === "Processing" || backup.status === "Queued"
+    );
+
+    set({ backups: backups ?? [], enablePolling, isLoading: false });
+  },
+
+  // Utility actions
+  clearBackupPolicy: () => set({ backupPolicy: null }),
+
+  setBackupPolicy: (policy: TBackupPolicy | null) => {
+    set({ backupPolicy: policy });
+  },
+
+  findBackupPolicy: (backupPolicyID: string): TBackupPolicy | undefined => {
+    return get().backupPolicies.find(
+      (policy) => policy.backupPolicyID === backupPolicyID
+    );
+  },
+}));

--- a/web/src/stores/backup.store.ts
+++ b/web/src/stores/backup.store.ts
@@ -129,7 +129,7 @@ export const useBackupStore = create<BackupStore>((set, get) => ({
     policy: Omit<TBackupPolicy, "backupPolicyID" | "connectionID" | "isDeleted">
   ) => {
     set({ isCreating: true });
-    const { backupPolicy, error } = await BackupAPI.CreateBackupPolicyRequest(
+    const { error } = await BackupAPI.CreateBackupPolicyRequest(
       connectionID,
       policy
     );
@@ -153,7 +153,7 @@ export const useBackupStore = create<BackupStore>((set, get) => ({
     policy: Partial<Omit<TBackupPolicy, "backupPolicyID" | "connectionID">>
   ) => {
     set({ isUpdating: true });
-    const { backupPolicy, error } = await BackupAPI.UpdateBackupPolicyRequest(
+    const { error } = await BackupAPI.UpdateBackupPolicyRequest(
       connectionID,
       backupPolicyID,
       policy


### PR DESCRIPTION
Summary
- Add backup scheduling, policies, and restore endpoints with cron-based dynamic job management.
- Implement scheduler service (safe add/remove/list) and initialize it on startup.
- Add backup domain types, policy fields (BackupPolicyID, IsDeleted, NextRun), and extended Backup model (policy, artifact, storage, deletion metadata, IsTriggered, BackupWithPolicyName).
- Implement backup controllers with CreateBackupPolicy and GetBackupPolicy; schedule active policies into cron.
- Add RestoreBackup controller and POST /restore/:ConnID/:BackupID/backup route to restore from backups; change snapshot restore POST route to include "/snapshot".
- Improve local storage initialization: create required folders in a loop to remove duplicated logic.
- Add services.InitCron wiring in main and services.RestoreBackup integration.

What changed
- services/scheduler.service.go: new scheduler service wrapping robfig/cron with safe operations and global SCHEDULER.
- main.go: call services.InitCron() and streamlined folder creation for "./_stuffs", "./_stuffs/snapshots", "./_stuffs/backups".
- src/interfaces/backup.interface.go: added BackupPolicy fields and extended Backup model + helper struct.
- src/controllers/backup.controller.go: CreateBackupPolicy and GetBackupPolicy implemented; scheduling active policies.
- src/controllers/restore.controller.go: RestoreBackup controller implemented.
- Routes: POST /restore/:ConnID/:BackupID/backup added; snapshot restore POST route adjusted.
- services: services.RestoreBackup added/used by controller to perform restore operations.

Notes
- Centralizes cron management to support dynamic backup policies and triggers.
- Enables listing and restoring backups with long-term retention metadata.