### PR TITLE
Add BSON tags to User model to fix missing userID on signup/login

### DIFF
--- a/src/interfaces/user.interface.go
+++ b/src/interfaces/user.interface.go
@@ -1,12 +1,12 @@
 package interfaces
 
 type User struct {
-	Username     string `json:"username"`
-	Password     string `json:"password"`
-	SessionToken string `json:"sessionToken"`
-	CSRFToken    string `json:"csrfToken"`
-	UserID       string `json:"userID"`
-	LastLogin    int64  `json:"lastLogin"`
+	Username     string `json:"username" bson:"username"`
+	Password     string `json:"password" bson:"password"`
+	SessionToken string `json:"sessionToken" bson:"sessionToken"`
+	CSRFToken    string `json:"csrfToken" bson:"csrfToken"`
+	UserID       string `json:"userID" bson:"userID"`
+	LastLogin    int64  `json:"lastLogin" bson:"lastLogin"`
 }
 
 type CreateUser struct {


### PR DESCRIPTION
### Motivation
- The MongoDB-decoded `User` struct fields were not mapped to the inserted camelCase BSON keys (e.g. `userID`, `sessionToken`), causing `UserID` to be empty after reads and breaking signup/login flows.

### Description
- Add explicit `bson` tags to all fields of `interfaces.User` in `src/interfaces/user.interface.go` so MongoDB decoding populates `UserID`, `SessionToken`, `CSRFToken`, and other fields; `CreateUser` and `LoginUser` payload structs remain unchanged.

### Testing
- Ran `go test ./src/interfaces` which passed, and `go test ./...` which failed due to unrelated build errors in `src/services/snapshot.service.go` (invalid `slog.Info` usage), confirming the change itself did not introduce new failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec62752988328a6f418fbe943b818)